### PR TITLE
Fix: fix the NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
-src
-config
 examples
 test
 tsconfig.json

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "scripts": {
     "info": "npm-scripts-info",
+    "install": "npm run build",
     "build": "trash build && yarn build:main && yarn build:module && yarn build:browser-deps && yarn build:browser && yarn build:browser-cjs && yarn build:resolve-sourcemaps",
     "build:main": "tsc -p tsconfig.json",
     "build:module": "tsc -p config/exports/tsconfig.module.json",
@@ -58,6 +59,7 @@
     "reset": "git clean -dfx && git reset --hard && yarn"
   },
   "scripts-info": {
+    "install": "Build the package automatically after installing it",
     "info": "Display information about the scripts",
     "build": "(Trash and re)build the library",
     "lint": "Lint all typescript source files",


### PR DESCRIPTION
Include the config & src folders in the NPM package and run the build
script after installing to build an usable library

* This PR adds the src and config folders to the NPM package and adds an automatic install script to build the library after installing it.



* Currently, after installing the library using NPM as a dependency, there is no usable code, since the src & config folders are not included in the NPM package and the build folder is not included in the Git repository.



* The package should automatically build itself after installing and export the library.