### PR TITLE
fix: typo in send coverage command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - attach_workspace:
           at: ~/tv-automation-mos-connection
       - run: yarn install
-      - run: yarn Send Coverage
+      - run: yarn send coverage
       - store_artifacts:
           path: ./coverage/clover.xml
           prefix: tests


### PR DESCRIPTION
When renaming, one of the commands were accidentialy renamed to
captial case.
