### PR TITLE
fix: yarn timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
           name: Publish to NPM with yarn
-          command: NEW_VERSION=$(node -p "require('./package.json').version") && yarn publish --access=public --new-version=$NEW_VERSION
+          command: NEW_VERSION=$(node -p "require('./package.json').version") && yarn publish --access=public --new-version=$NEW_VERSION --network-timeout 100000
       # I have read that some people are experiencing problems with yars publish. Change to npm publish, as below, if that happens.
       # - deploy:
       #     name: Publish to NPM with npm


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Yarn times out when publishing. Adding a larger network-timeout


* **What is the current behavior?** (You can also link to an open issue here)
Yarn publish fails due to timeout


* **What is the new behavior (if this is a feature change)?**
Yarn should hopefully not fail again.


* **Other information**:
