### PR TITLE
fix: remove persist to workspace on last step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,9 +99,6 @@ jobs:
       # - deploy:
       #     name: Publish to NPM with npm
       #     command: npm publish --access=public
-      - persist_to_workspace:
-          root: .
-          paths: [.]
 
 workflows:
   version: 2


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove unnecessary last step (persist to workspace)


* **What is the current behavior?** (You can also link to an open issue here)
Has a last step which is not needed


* **What is the new behavior (if this is a feature change)?**
Skip this persist to workspace.


* **Other information**:
