### PR TITLE
fix: use generic project name in config. Add more steps to do

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   docker:
     - image: circleci/node:8
-  working_directory: ~/tv-automation-mos-connection
+  working_directory: ~/project
 
 version: 2
 jobs:
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ~/tv-automation-mos-connection
+          at: ~/project
       - restore_cache:
           keys:
             - yarn-cache-{{ .Branch }}-{{ checksum "yarn.lock" }}
@@ -27,21 +27,21 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: ~/tv-automation-mos-connection
+          at: ~/project
       - run: yarn install
       - run: yarn validate:dependencies
   Test node-8:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: ~/tv-automation-mos-connection
+          at: ~/project
       - run: yarn install
       - run: yarn ci
   Send Coverage:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: ~/tv-automation-mos-connection
+          at: ~/project
       - run: yarn install
       - run: yarn send-coverage
       - store_artifacts:
@@ -57,7 +57,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: ~/tv-automation-mos-connection
+          at: ~/project
       - run: yarn install
       - run: yarn build
       - persist_to_workspace:
@@ -68,7 +68,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: ~/tv-automation-mos-connection
+          at: ~/project
       - add_ssh_keys:
           fingerprints:
             - "fe:e8:83:0c:e9:a3:83:47:db:a9:f4:ce:a3:1f:7e:28"
@@ -88,7 +88,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: ~/mos-connection
+          at: ~/project
       - run:
           name: Write NPM Token to ~/.npmrc
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
@@ -102,7 +102,7 @@ jobs:
 
 workflows:
   version: 2
-  Test build and deploy(master):
+  Test build and deploy(master only):
     jobs:
       - Checkout Code
       - Check for vulnerabilities:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ These are all the major changes introduced by thin new revision. This is kept he
 3. Some code changes to make docs-commands work
 4. Setup project on CircleCI
 5. Added NPM_TOKEN to CircleCI
-6. Set up ssh-key with write permissions on CircleCI and GitHub (`ssh-keygen -t rsa -b 4096 -C "your_email@example.com"`, upload .pub to github, and private to CircleCI)
+6. Set up ssh-key with write permissions on CircleCI and GitHub (`ssh-keygen -t rsa -b 4096 -C "your_email@example.com"`, upload .pub to github, and private to CircleCI) Remember to allow write access on github
 7. Adding protected branch, master, to github ("Protect this branch" => "Require status checks to pass before merging" => "Require branches to be up to date before merging" => Don't select anything here )
 8. Fixed coverage-reports, and set required line-coverage++ to 0%. This way the coverage reports are generated without blocking a release.
 9. Set up codecov for project
@@ -18,3 +18,7 @@ These are all the major changes introduced by thin new revision. This is kept he
 13. Update .npmignore. Make sure to include all the needed files, and nothing more. Minimal release etc. etc.
 14. Update .gitignore. Remove things like coverage, docs, and so forth.
 15. Remove travis
+16. Fix license
+17. Check for "superfly" references
+18. Make sure `--forceExit` is set on the `"unit"` script.
+19. Make sure to build docs as part of ci-test: `"ci": "yarn test && yarn docs:test",`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,9 @@
 
 These are all the major changes introduced by thin new revision. This is kept here for reference for the other repositories.
 
-1. CircleCI config changes (see diff)
-2. Some minor changes to package.json
-3. Some code changes to make docs-commands work
+1. CircleCI config. Copy from other project, update Fingerprint (after step 6.)
+2. Some minor changes to package.json (scripts + script-info + contributor)
+3. Some code changes to make docs-commands work (`yarn docs:html`)
 4. Setup project on CircleCI
 5. Added NPM_TOKEN to CircleCI
 6. Set up ssh-key with write permissions on CircleCI and GitHub (`ssh-keygen -t rsa -b 4096 -C "your_email@example.com"`, upload .pub to github, and private to CircleCI) Remember to allow write access on github


### PR DESCRIPTION
Just some minor changes to make the config more generic, and for me to remember more in detail what to do when applying to next projects.