### PR TITLE
Feature/xml fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,13 +117,11 @@
     "production"
   ],
   "dependencies": {
-    "@types/xml2js": "^0.4.2",
     "@types/xml2json": "^0.10.0",
     "@types/xmlbuilder": "^0.0.32",
     "moment": "^2.20.1",
     "tslib": "^1.6.0",
     "xml-js": "^1.6.4",
-    "xml2js": "^0.4.19",
     "xml2json": "^0.11.2",
     "xmlbuilder": "^9.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@types/xmlbuilder": "^0.0.32",
     "moment": "^2.20.1",
     "tslib": "^1.6.0",
+    "xml-js": "^1.6.4",
     "xml2js": "^0.4.19",
     "xml2json": "^0.11.2",
     "xmlbuilder": "^9.0.7"

--- a/package.json
+++ b/package.json
@@ -117,12 +117,10 @@
     "production"
   ],
   "dependencies": {
-    "@types/xml2json": "^0.10.0",
     "@types/xmlbuilder": "^0.0.32",
     "moment": "^2.20.1",
     "tslib": "^1.6.0",
     "xml-js": "^1.6.4",
-    "xml2json": "^0.11.2",
     "xmlbuilder": "^9.0.7"
   },
   "standard-version": {

--- a/src/MosConnection.ts
+++ b/src/MosConnection.ts
@@ -354,10 +354,10 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 					parsed = xml2js(messageString)
 				} else if (last === lastMatch) {
 					// Last chunk, ready to parse with saved data:
-					parsed = xml2js(messageString)
+					parsed = xml2js(client.chunks + messageString)
 					client.chunks = ''
 				} else if (first === firstMatch) {
-					// Chunk, save for later:
+					// First chunk, save for later:
 					client.chunks = messageString
 				} else {
 					// Chunk, save for later:

--- a/src/MosConnection.ts
+++ b/src/MosConnection.ts
@@ -9,7 +9,7 @@ import {
 import { MosDevice } from './MosDevice'
 import { SocketServerEvent, SocketDescription, IncomingConnectionType } from './connection/socketConnection'
 import { NCSServerConnection } from './connection/NCSServerConnection'
-import * as parser from 'xml2json'
+import { xml2js } from './utils/Utils'
 import { MosMessage } from './mosModel/MosMessage'
 import { MOSAck } from './mosModel/mosAck'
 import { MosString128 } from './dataTypes/mosString128'
@@ -339,11 +339,6 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 			if (this._debug) console.log(`Socket got data (${socketID}, ${client.socket.remoteAddress}, ${client.portDescription}): ${data}`)
 
 			let parsed: any = null
-			let parseOptions: any = {
-				object: true,
-				coerce: true,
-				trim: true
-			}
 			let firstMatch = '<mos>' // <mos>
 			let first = messageString.substr(0, firstMatch.length)
 			let lastMatch = '</mos>' // </mos>
@@ -356,10 +351,10 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 				// console.log(messageString)
 				if (first === firstMatch && last === lastMatch) {
 					// Data ready to be parsed:
-					parsed = parser.toJson(messageString, parseOptions)
+					parsed = xml2js(messageString)
 				} else if (last === lastMatch) {
 					// Last chunk, ready to parse with saved data:
-					parsed = parser.toJson(client.chunks + messageString, parseOptions)
+					parsed = xml2js(messageString)
 					client.chunks = ''
 				} else if (first === firstMatch) {
 					// Chunk, save for later:

--- a/src/__tests__/MosConnection.spec.ts
+++ b/src/__tests__/MosConnection.spec.ts
@@ -1173,12 +1173,17 @@ describe('MosDevice: Profile 4', () => {
 		let o = Object.assign({}, xmlApiData.roStorySend)
 		delete o.Body
 		expect(onROStory.mock.calls[0][0]).toMatchObject(o)
-		xmlApiData.roStorySend.Body.forEach((item, key) => {
+		xmlApiData.roStorySend.Body.forEach((testItem, key) => {
+			let item: any
 			try {
+				item = onROStory.mock.calls[0][0].Body[key]
+				if (!testItem.Content) delete testItem.Content
 
-				expect(onROStory.mock.calls[0][0].Body[key]).toMatchObject(item)
+				expect(item).toMatchObject(testItem)
 			} catch (e) {
 				console.log(key)
+				console.log('item', item)
+				console.log('testItem', testItem)
 				throw e
 			}
 		})

--- a/src/__tests__/MosConnection.spec.ts
+++ b/src/__tests__/MosConnection.spec.ts
@@ -24,18 +24,8 @@ import { SocketMock } from '../__mocks__/socket'
 import { ServerMock } from '../__mocks__/server'
 
 import { xmlData, xmlApiData } from './testData.spec'
-import * as parser from 'xml2json'
+import { xml2js } from 'xml-js'
 import { MosDevice } from '../MosDevice'
-
-const parseOptions: {
-	object: true,
-	coerce: boolean,
-	trim: boolean
-} = {
-	object: true,
-	coerce: true,
-	trim: true
-}
 
 const iconv = require('iconv-lite')
 iconv.encodingExists('utf16-be')
@@ -598,10 +588,10 @@ describe('MosDevice: Profile 1', () => {
 		expect(serverSocketMockLower.mockSentMessage).toHaveBeenCalledTimes(1)
 		// // @ts-ignore mock
 		let reply = decode(serverSocketMockLower.mockSentMessage['mock'].calls[0][0])
-		let parsedReply: any = parser.toJson(reply, parseOptions)
+		let parsedReply: any = xml2js(reply, { compact: true, nativeType: true, trim: true })
 
-		expect(parsedReply.mos.mosObj.objID + '').toEqual(xmlApiData.mosObj.ID.toString())
-		expect(parsedReply.mos.mosObj.objSlug + '').toEqual(xmlApiData.mosObj.Slug.toString())
+		expect(parsedReply.mos.mosObj.objID._text + '').toEqual(xmlApiData.mosObj.ID.toString())
+		expect(parsedReply.mos.mosObj.objSlug._text + '').toEqual(xmlApiData.mosObj.Slug.toString())
 	})
 	test('onRequestAllMOSObjects', async () => {
 		// Fake incoming message on socket:
@@ -615,12 +605,12 @@ describe('MosDevice: Profile 1', () => {
 		expect(serverSocketMockLower.mockSentMessage).toHaveBeenCalledTimes(1)
 		// @ts-ignore mock
 		let reply = decode(serverSocketMockLower.mockSentMessage.mock.calls[0][0])
-		let parsedReply: any = parser.toJson(reply, parseOptions)
+		let parsedReply: any = xml2js(reply, { compact: true, nativeType: true, trim: true })
 		expect(parsedReply.mos.mosListAll.mosObj).toHaveLength(2)
-		expect(parsedReply.mos.mosListAll.mosObj[0].objID + '').toEqual(xmlApiData.mosObj.ID.toString())
-		expect(parsedReply.mos.mosListAll.mosObj[0].objSlug + '').toEqual(xmlApiData.mosObj.Slug.toString())
-		expect(parsedReply.mos.mosListAll.mosObj[1].objID + '').toEqual(xmlApiData.mosObj2.ID.toString())
-		expect(parsedReply.mos.mosListAll.mosObj[1].objSlug + '').toEqual(xmlApiData.mosObj2.Slug.toString())
+		expect(parsedReply.mos.mosListAll.mosObj[0].objID._text + '').toEqual(xmlApiData.mosObj.ID.toString())
+		expect(parsedReply.mos.mosListAll.mosObj[0].objSlug._text + '').toEqual(xmlApiData.mosObj.Slug.toString())
+		expect(parsedReply.mos.mosListAll.mosObj[1].objID._text + '').toEqual(xmlApiData.mosObj2.ID.toString())
+		expect(parsedReply.mos.mosListAll.mosObj[1].objSlug._text + '').toEqual(xmlApiData.mosObj2.Slug.toString())
 
 	})
 	test('getMOSObject', async () => {
@@ -895,17 +885,17 @@ describe('MosDevice: Profile 2', () => {
 		// console.log(decode(serverSocketMockUpper.mockSentMessage.mock.calls[0][0]))
 		// @ts-ignore mock
 		let reply = decode(serverSocketMockUpper.mockSentMessage.mock.calls[0][0])
-		let parsedReply: any = parser.toJson(reply, parseOptions)
+		let parsedReply: any = xml2js(reply, { compact: true, nativeType: true, trim: true })
 		// console.log('parsedReply',parsedReply.mos)
 
 		// expect(parsedReply.mos.roList).toMatchObject(roLight(xmlApiData.roCreate))
-		expect(parsedReply.mos.roList.roID + '').toEqual(xmlApiData.roCreate.ID.toString())
-		expect(parsedReply.mos.roList.roSlug + '').toEqual(xmlApiData.roCreate.Slug.toString())
+		expect(parsedReply.mos.roList.roID._text + '').toEqual(xmlApiData.roCreate.ID.toString())
+		expect(parsedReply.mos.roList.roSlug._text + '').toEqual(xmlApiData.roCreate.Slug.toString())
 		expect(parsedReply.mos.roList.story).toHaveLength(xmlApiData.roCreate.Stories.length)
-		expect(parsedReply.mos.roList.story[0].storyID + '').toEqual(xmlApiData.roCreate.Stories[0].ID.toString())
+		expect(parsedReply.mos.roList.story[0].storyID._text + '').toEqual(xmlApiData.roCreate.Stories[0].ID.toString())
 		expect(parsedReply.mos.roList.story[0].item).toBeTruthy()
-		expect(parsedReply.mos.roList.story[0].item.itemID + '').toEqual(xmlApiData.roCreate.Stories[0].Items[0].ID.toString())
-		expect(parsedReply.mos.roList.story[0].item.objID + '').toEqual(xmlApiData.roCreate.Stories[0].Items[0].ObjectID.toString())
+		expect(parsedReply.mos.roList.story[0].item.itemID._text + '').toEqual(xmlApiData.roCreate.Stories[0].Items[0].ID.toString())
+		expect(parsedReply.mos.roList.story[0].item.objID._text + '').toEqual(xmlApiData.roCreate.Stories[0].Items[0].ObjectID.toString())
 
 	})
 	test('getRunningOrder', async () => {

--- a/src/__tests__/MosConnection.spec.ts
+++ b/src/__tests__/MosConnection.spec.ts
@@ -1164,14 +1164,28 @@ describe('MosDevice: Profile 4', () => {
 		expect(socketMockLower).toBeTruthy()
 		expect(socketMockUpper).toBeTruthy()
 	})
-	// test('onROStory', async () => {
-	// 	// Fake incoming message on socket:
+	test('onROStory', async () => {
+		// Fake incoming message on socket:
 
-	// 	let messageId = await fakeIncomingMessage(serverSocketMockLower, xmlData.roStorySend)
-	// 	expect(onROStory).toHaveBeenCalledTimes(1)
-	// 	expect(onROStory.mock.calls[0][0]).toMatchObject(xmlApiData.roStorySend)
-	// 	await checkReplyToServer(serverSocketMockLower, messageId, '<roAck>')
-	// })
+		let messageId = await fakeIncomingMessage(serverSocketMockLower, xmlData.roStorySend)
+		expect(onROStory).toHaveBeenCalledTimes(1)
+
+		let o = Object.assign({}, xmlApiData.roStorySend)
+		delete o.Body
+		expect(onROStory.mock.calls[0][0]).toMatchObject(o)
+		xmlApiData.roStorySend.Body.forEach((item, key) => {
+			try {
+
+				expect(onROStory.mock.calls[0][0].Body[key]).toMatchObject(item)
+			} catch (e) {
+				console.log(key)
+				throw e
+			}
+		})
+		await checkReplyToServer(serverSocketMockLower, messageId, '<roAck>')
+
+		// expect(onROStory.mock.calls[0][0]).toMatchObject(xmlApiData.roStorySend)
+	})
 	test('getAllRunningOrders', async () => {
 		// Prepare server response
 		let mockReply = jest.fn((data) => {

--- a/src/__tests__/testData.spec.ts
+++ b/src/__tests__/testData.spec.ts
@@ -1374,7 +1374,7 @@ let xmlApiData = {
 								attributes: {
 									type: 'video',
 									changedBy: 'N11580',
-									changetime: '2014-10-06T13:24:32 +02:00',
+									changetime: '2014-10-06T13:24:32 +02:00'
 								},
 								title: '',
 								description: '',
@@ -1493,7 +1493,7 @@ let xmlApiData = {
 							MosItemEditorProgID: new MosString128('Chymox.AssetBrowser.1')
 						})
 					]
-				},
+				}
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',

--- a/src/__tests__/testData.spec.ts
+++ b/src/__tests__/testData.spec.ts
@@ -1347,17 +1347,17 @@ let xmlApiData = {
 		Body: [
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',
-				Content: ' '
+				Content: ''
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'storyItem',
 				Content: literal<IMOSItem>({
 					ID: new MosString128('2'),
-					Slug: new MosString128('M: '),
+					Slug: new MosString128('SAK BUSKERUD;SAK-14'),
 					ObjectID: new MosString128('N11580_1412594672'),
 					MOSID: 'METADATA.NRK.MOS',
 					mosAbstract: 'METADATA',
-					ItemSlug: new MosString128('SAK BUSKERUD;SAK-14'),
+					ObjectSlug: new MosString128('M:'),
 					// Paths?: Array<IMOSObjectPath>,
 					// Channel?: new MosString128(''),
 					// EditorialStart?: number,
@@ -1371,20 +1371,20 @@ let xmlApiData = {
 						MosSchema: 'http://mosA4.com/mos/supported_schemas/MOSAXML2.08',
 						MosPayload: {
 							nrk: {
-								type: 'video',
-								changedBy: 'N11580',
-								changetime: '2014-10-06T13:24:32 +02:00',
-								c: {
-									title: '',
-									description: '',
-									hbbtv: {
-										link: ''
-									},
-									rights: {
-										notes: '',
-										owner: 'NRK',
-										c: 'Green'
-									}
+								attributes: {
+									type: 'video',
+									changedBy: 'N11580',
+									changetime: '2014-10-06T13:24:32 +02:00',
+								},
+								title: '',
+								description: '',
+								hbbtv: {
+									link: ''
+								},
+								rights: {
+									notes: '',
+									owner: 'NRK',
+									text: 'Green'
 								}
 							}
 						}
@@ -1394,15 +1394,15 @@ let xmlApiData = {
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',
-				Content: ' '
+				Content: ''
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',
-				Content: ' '
+				Content: ''
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',
-				Content: ' '
+				Content: ''
 			}),
 			// literal<IMOSROFullStoryBodyItem>({
 			literal<IMOSROFullStoryBodyItem>({
@@ -1413,7 +1413,7 @@ let xmlApiData = {
 					// ObjectID: new MosString128(''),
 					MOSID: 'chyron.techycami02.ndte.nrk.mos',
 					mosAbstract: '_00:00:02:00 | @M=Auto Timed | 01 ett navn | 1: | 2: | 3: | 4: | 00:00:05:00',
-					ItemSlug: new MosString128('01 ett navn 1:&#160;&#160;2:'),
+					Slug: new MosString128('01 ett navn 1:\xa0\xa02:'), // &nbsp = 160
 					Paths: [
 						literal<IMOSObjectPath>({
 							Type: IMOSObjectPathType.PROXY_PATH,
@@ -1428,36 +1428,36 @@ let xmlApiData = {
 					// Trigger?: any
 					// MacroIn?: new MosString128(''),
 					// MacroOut?: new MosString128(''),
-					MosExternalMetaData: [literal<IMOSExternalMetaData>({
-						MosScope: IMOSScope.PLAYLIST,
-						MosSchema: '',
-						MosPayload: {
-							nrk: {
-								type: '',
-								changedBy: '',
-								changetime: '',
-								c: {
-									title: '',
-									description: '',
-									hbbtv: {
-										link: ''
-									},
-									rights: {
-										notes: '',
-										owner: '',
-										c: ''
-									}
-								}
-							}
-						}
-					})],
+					// MosExternalMetaData: [literal<IMOSExternalMetaData>({
+					// 	MosScope: IMOSScope.PLAYLIST,
+					// 	MosSchema: '',
+					// 	MosPayload: {
+					// 		nrk: {
+					// 			type: '',
+					// 			changedBy: '',
+					// 			changetime: '',
+
+					// 			title: '',
+					// 			description: '',
+					// 			hbbtv: {
+					// 				link: ''
+					// 			},
+					// 			rights: {
+					// 				notes: '',
+					// 				owner: '',
+					// 				text: ''
+					// 			}
+
+					// 		}
+					// 	}
+					// })],
 					MosObjects: [
 						literal<IMOSObject>({
 							ID: new MosString128('NYHETER\\00039287?version=1'),
-							Slug: new MosString128('01 ett navn 1:&#160;&#160;2:'),
+							Slug: new MosString128('01 ett navn 1:\xa0\xa02:'), // &nbsp = 160
 							// MosAbstract?: '',
 							// Group?: '',
-							Type: IMOSObjectType.OTHER,
+							Type: undefined,
 							TimeBase: 0,
 							// Revision: number, // max 999
 							Duration: 0,
@@ -1485,7 +1485,7 @@ let xmlApiData = {
 									subtype: 'lyric/data',
 									subtypeid: 'I:\\CAMIO\\NYHETER\\Templates\\Super\\00000001.lyr',
 									ObjectDetails: {
-										ServerID: 'chyron.techycami02.ndte.n \r\n--------------------------------------------------------\r\n \nrk.mos',
+										ServerID: 'chyron.techycami02.ndte.n    --------------------------------------------------------    rk.mos',
 										ServerURL: 'http://160.68.33.159/CAMIO/Redirection/MOSRedirection.asmx'
 									}
 								}
@@ -1497,7 +1497,7 @@ let xmlApiData = {
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',
-				Content: ' '
+				Content: ''
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'storyItem'
@@ -1505,11 +1505,7 @@ let xmlApiData = {
 			} as IMOSROFullStoryBodyItem), // tmp
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',
-				Content: ' '
-			}),
-			literal<IMOSROFullStoryBodyItem>({
-				Type: 'p',
-				Content: ' '
+				Content: ''
 			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'storyItem'
@@ -1517,7 +1513,7 @@ let xmlApiData = {
 			} as IMOSROFullStoryBodyItem), // tmp
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'p',
-				Content: ' '
+				Content: ''
 			})
 
 			// <p> </p>

--- a/src/__tests__/testData.spec.ts
+++ b/src/__tests__/testData.spec.ts
@@ -16,7 +16,8 @@ import {
 	IMOSStoryAction,
 	IMOSItemAction,
 	IMOSROAction,
-	IMOSROFullStory
+	IMOSROFullStory,
+	IMOSROFullStoryBodyItem
 } from '../api'
 import { MosString128 } from '../dataTypes/mosString128'
 import { MosTime } from '../dataTypes/mosTime'
@@ -1342,12 +1343,12 @@ let xmlApiData = {
 		// MacroIn?: MosString128,
 		// MacroOut?: MosString128,
 		// MosExternalMetaData?: Array<IMOSExternalMetaData>,
-		Body: []
-		/*Body: [
-			// literal<IMOSROFullStoryBodyItem>({
-			// 	Type: 'p',
-			// 	Content: ' '
-			// }),
+		// Body: []
+		Body: [
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
+			}),
 			literal<IMOSROFullStoryBodyItem>({
 				Type: 'storyItem',
 				Content: literal<IMOSItem>({
@@ -1356,12 +1357,13 @@ let xmlApiData = {
 					ObjectID: new MosString128('N11580_1412594672'),
 					MOSID: 'METADATA.NRK.MOS',
 					mosAbstract: 'METADATA',
+					ItemSlug: new MosString128('SAK BUSKERUD;SAK-14'),
 					// Paths?: Array<IMOSObjectPath>,
 					// Channel?: new MosString128(''),
 					// EditorialStart?: number,
 					// EditorialDuration?: number,
 					// UserTimingDuration?: number,
-					// Trigger?: any // TODO: Johan frågar
+					// Trigger?: any
 					// MacroIn?: new MosString128(''),
 					// MacroOut?: new MosString128(''),
 					MosExternalMetaData: [literal<IMOSExternalMetaData>({
@@ -1389,8 +1391,148 @@ let xmlApiData = {
 					})]
 					// MosObjects?: Array<IMOSObject>
 				})
+			}),
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
+			}),
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
+			}),
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
+			}),
+			// literal<IMOSROFullStoryBodyItem>({
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'storyItem',
+				Content: {
+					ID: new MosString128('3'),
+					// Slug: new MosString128(''),
+					// ObjectID: new MosString128(''),
+					MOSID: 'chyron.techycami02.ndte.nrk.mos',
+					mosAbstract: '_00:00:02:00 | @M=Auto Timed | 01 ett navn | 1: | 2: | 3: | 4: | 00:00:05:00',
+					ItemSlug: new MosString128('01 ett navn 1:&#160;&#160;2:'),
+					Paths: [
+						literal<IMOSObjectPath>({
+							Type: IMOSObjectPathType.PROXY_PATH,
+							Description: 'JPEG Thumbnail',
+							Target: 'http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039287_v1_big.jpg'
+						})
+					],
+					Channel: new MosString128('CG1'),
+					// EditorialStart?: number,
+					// EditorialDuration?: number,
+					// UserTimingDuration?: number,
+					// Trigger?: any
+					// MacroIn?: new MosString128(''),
+					// MacroOut?: new MosString128(''),
+					MosExternalMetaData: [literal<IMOSExternalMetaData>({
+						MosScope: IMOSScope.PLAYLIST,
+						MosSchema: '',
+						MosPayload: {
+							nrk: {
+								type: '',
+								changedBy: '',
+								changetime: '',
+								c: {
+									title: '',
+									description: '',
+									hbbtv: {
+										link: ''
+									},
+									rights: {
+										notes: '',
+										owner: '',
+										c: ''
+									}
+								}
+							}
+						}
+					})],
+					MosObjects: [
+						literal<IMOSObject>({
+							ID: new MosString128('NYHETER\\00039287?version=1'),
+							Slug: new MosString128('01 ett navn 1:&#160;&#160;2:'),
+							// MosAbstract?: '',
+							// Group?: '',
+							Type: IMOSObjectType.OTHER,
+							TimeBase: 0,
+							// Revision: number, // max 999
+							Duration: 0,
+							// Status: IMOSObjectStatus,
+							// AirStatus: IMOSObjectAirStatus,
+							Paths: [
+								literal<IMOSObjectPath>({
+									Type: IMOSObjectPathType.PROXY_PATH,
+									Description: 'JPEG Thumbnail',
+									Target: 'http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039287_v1_big.jpg'
+								})
+							],
+							// CreatedBy: new MosString128(''),
+							// Created: MosTime
+							// ChangedBy?: new MosString128(''), // if not present, defaults to CreatedBy
+							// Changed?: MosTime // if not present, defaults to Created
+							// Description?: any // xml json
+							MosExternalMetaData: [literal<IMOSExternalMetaData>({
+								MosScope: IMOSScope.PLAYLIST,
+								MosSchema: 'http://ncsA4.com/mos/supported_schemas/NCSAXML2.08',
+								MosPayload: {
+									sAVsom: '00:00:02:00',
+									sAVeom: '00:00:05:00',
+									createdBy: 'N12050',
+									subtype: 'lyric/data',
+									subtypeid: 'I:\\CAMIO\\NYHETER\\Templates\\Super\\00000001.lyr',
+									ObjectDetails: {
+										ServerID: 'chyron.techycami02.ndte.n \r\n--------------------------------------------------------\r\n \nrk.mos',
+										ServerURL: 'http://160.68.33.159/CAMIO/Redirection/MOSRedirection.asmx'
+									}
+								}
+							})],
+							MosItemEditorProgID: new MosString128('Chymox.AssetBrowser.1')
+						})
+					]
+				},
+			}),
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
+			}),
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'storyItem'
+				// Content: {},
+			} as IMOSROFullStoryBodyItem), // tmp
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
+			}),
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
+			}),
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'storyItem'
+				// Content: {},
+			} as IMOSROFullStoryBodyItem), // tmp
+			literal<IMOSROFullStoryBodyItem>({
+				Type: 'p',
+				Content: ' '
 			})
-		]*/
+
+			// <p> </p>
+			// <storyItem><itemID>2</itemID><objID>N11580_1412594672</objID><mosID>METADATA.NRK.MOS</mosID><mosAbstract>METADATA</mosAbstract><objSlug>M: </objSlug><mosExternalMetadata><mosScope>PLAYLIST</mosScope><mosSchema>http://mosA4.com/mos/supported_schemas/MOSAXML2.08</mosSchema><mosPayload><nrk type="video" changedBy="N11580" changetime="2014-10-06T13:24:32 +02:00"><title></title><description></description><hbbtv link=""></hbbtv><rights notes="" owner="NRK">Green</rights></nrk></mosPayload></mosExternalMetadata><itemSlug>SAK BUSKERUD;SAK-14</itemSlug></storyItem>
+			// <p> </p> \
+			// <p> </p> \
+			// <p> </p>
+			// <storyItem><mosID>chyron.techycami02.ndte.nrk.mos</mosID><mosAbstract>_00:00:02:00 | @M=Auto Timed | 01 ett navn | 1: | 2: | 3: | 4: | 00:00:05:00</mosAbstract><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039287_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><itemChannel>CG1</itemChannel><itemSlug>01 ett navn 1:&#160;&#160;2:</itemSlug><mosObj><objID>NYHETER\\00039287?version=1</objID><objSlug>01 ett navn 1:&#160;&#160;2:</objSlug><mosItemEditorProgID>Chymox.AssetBrowser.1</mosItemEditorProgID><objDur>0</objDur><objTB>0</objTB><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039287_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><mosExternalMetadata><mosScope>PLAYLIST</mosScope><mosSchema>http://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema><mosPayload><sAVsom>00:00:02:00</sAVsom><sAVeom>00:00:05:00</sAVeom><createdBy>N12050</createdBy><subtype>lyric/data</subtype><subtypeid>I:\\CAMIO\\NYHETER\\Templates\\Super\\00000001.lyr</subtypeid><ObjectDetails><ServerID>chyron.techycami02.ndte.n \r\n--------------------------------------------------------\r\n \nrk.mos</ServerID><ServerURL>http://160.68.33.159/CAMIO/Redirection/MOSRedirection.asmx</ServerURL></ObjectDetails></mosPayload></mosExternalMetadata></mosObj><itemID>3</itemID></storyItem>
+			// <p> </p>
+			// <storyItem><mosID>chyron.techycami02.ndte.nrk.mos</mosID><mosAbstract>_00:00:02:00 | @M=Auto Timed | 01 ett navn | 1: | 2: | 3: | 4: | 00:00:05:00</mosAbstract><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039288_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><itemChannel>CG1</itemChannel><itemSlug>01 ett navn 1:&#160;&#160;2:</itemSlug><mosObj><objID>NYHETER\\00039288?version=1</objID><objSlug>01 ett navn 1:&#160;&#160;2:</objSlug><mosItemEditorProgID>Chymox.AssetBrowser.1</mosItemEditorProgID><objDur>0</objDur><objTB>0</objTB><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039288_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><mosExternalMetadata><mosScope>PLAYLIST</mosScope><mosSchema>http://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema><mosPayload><sAVsom>00:00:02:00</sAVsom><sAVeom>00:00:05:00</sAVeom><createdBy>N12050</createdBy><subtype>lyric/data</subtype><subtypeid>I:\\CAMIO\\NYHETER\\Templates\\Super\\00000001.lyr</subtypeid><ObjectDetails><ServerID>chyron.techycami02.ndte.nrk.mos</ServerID><ServerURL>http://160.68.33.159/CAMIO/Redirection/MOSRedirection.asmx</ServerURL></ObjectDetails></mosPayload></mosExternalMetadata></mosObj><itemID>4</itemID></storyItem><p> </p><storyItem><mosID>chyron.techycami02.ndte.nrk.mos</mosID><mosAbstract>_00:00:02:00 | @M=Auto Timed | 01 ett navn | 1: | 2: | 3: | 4: | 00:00:05:00</mosAbstract><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039289_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><itemChannel>CG1</itemChannel><itemSlug>01 ett navn 1:&#160;&#160;2:</itemSlug><mosObj><objID>NYHETER\\00039289?version=1</objID><objSlug>01 ett navn 1:&#160;&#160;2:</objSlug><mosItemEditorProgID>Chymox.AssetBrowser.1</mosItemEditorProgID><objDur>0</objDur><objTB>0</objTB><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039289_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><mosExternalMetadata><mosScope>PLAYLIST</mosScope><mosSchema>http://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema><mosPayload><sAVsom>00:00:02:00</sAVsom><sAVeom>00:00:05:00</sAVeom><createdBy>N12050</createdBy><subtype>lyric/data</subtype><subtypeid>I:\\CAMIO\\NYHETER\\Templates\\Super\\00000001.lyr</subtypeid><ObjectDetails><ServerID>chyron.techycami02.ndte.nrk.mos</ServerID><ServerURL>http://160.68.33.159/CAMIO/Redirection/MOSRedirection.asmx</ServerURL></ObjectDetails></mosPayload></mosExternalMetadata></mosObj><itemID>5</itemID></storyItem><p> </p><storyItem><mosID>chyron.techycami02.ndte.nrk.mos</mosID><mosAbstract>_00:00:02:00 | @M=Auto Timed | 01 ett navn | 1: | 2: | 3: | 4: | 00:00:05:00</mosAbstract><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039290_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><itemChannel>CG1</itemChannel><itemSlug>01 ett navn 1:&#160;&#160;2:</itemSlug><mosObj><objID>NYHETER\\00039290?version=1</objID><objSlug>01 ett navn 1:&#160;&#160;2:</objSlug><mosItemEditorProgID>Chymox.AssetBrowser.1</mosItemEditorProgID><objDur>0</objDur><objTB>0</objTB><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039290_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><mosExternalMetadata><mosScope>PLAYLIST</mosScope><mosSchema>http://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema><mosPayload><sAVsom>00:00:02:00</sAVsom><sAVeom>00:00:05:00</sAVeom><createdBy>N12050</createdBy><subtype>lyric/data</subtype><subtypeid>I:\\CAMIO\\NYHETER\\Templates\\Super\\00000001.lyr</subtypeid><ObjectDetails><ServerID>chyron.techycami02.ndte.nrk.mos</ServerID><ServerURL>http://160.68.33.159/CAMIO/Redirection/MOSRedirection.asmx</ServerURL></ObjectDetails></mosPayload></mosExternalMetadata></mosObj><itemID>6</itemID></storyItem><p> </p><storyItem><mosID>chyron.techycami02.ndte.nrk.mos</mosID><mosAbstract>_00:00:02:00 | @M=Auto Timed | 24 foto/red | 1:Foto og redigering: | 2: | 3: | 4: | 00:00:05:00</mosAbstract><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039291_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><itemChannel>CG1</itemChannel><itemSlug>24 foto/red 1:Foto og redigering:&#160;&#160;2:</itemSlug><mosObj><objID>NYHETER\\00039291?version=1</objID><objSlug>24 foto/red 1:Foto og redigering:&#160;&#160;2:</objSlug><mosItemEditorProgID>Chymox.AssetBrowser.1</mosItemEditorProgID><objDur>0</objDur><objTB>0</objTB><objPaths><objProxyPath techDescription="JPEG Thumbnail">http://160.68.33.159/thumbs/NYHETER/39000/Objects_NYHETER_00039291_v1_big.jpg</objProxyPath><objMetadataPath></objMetadataPath></objPaths><mosExternalMetadata><mosScope>PLAYLIST</mosScope><mosSchema>http://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema><mosPayload><sAVsom>00:00:02:00</sAVsom><sAVeom>00:00:05:00</sAVeom><createdBy>N12050</createdBy><subtype>lyric/data</subtype><subtypeid>I:\\CAMIO\\NYHETER\\Templates\\Super\\00000024.lyr</subtypeid><ObjectDetails><ServerID>chyron.techycami02.ndte.nrk.mos</ServerID><ServerURL>http://160.68.33.159/CAMIO/Redirection/MOSRedirection.asmx</ServerURL></ObjectDetails></mosPayload></mosExternalMetadata></mosObj><itemID>7</itemID></storyItem>
+			// <p> </p> \
+			// <p> </p>
+			// <storyItem><mosID>mosart.morten.mos</mosID><mosAbstract>TIDSMARKØR IKKE RØR</mosAbstract><objID>STORYSTATUS</objID><objSlug>Story status</objSlug><itemID>8</itemID><itemSlug>SAK BUSKERUD;SAK-20</itemSlug></storyItem>
+			// <p> </p>
+		]
 	}),
 	'roListAll': [
 		literal<IMOSRunningOrderBase>({

--- a/src/api.ts
+++ b/src/api.ts
@@ -185,6 +185,7 @@ export interface IMOSROFullStoryBodyItem {
 export interface IMOSItem {
 	ID: MosString128
 	Slug?: MosString128
+	ItemSlug?: MosString128
 	ObjectID: MosString128
 	MOSID: string
 	mosAbstract?: string
@@ -271,23 +272,25 @@ export interface IMOSObject {
 	Group?: string
 	Type: IMOSObjectType
 	TimeBase: number
-	Revision: number // max 999
+	Revision?: number // max 999
 	Duration: number
-	Status: IMOSObjectStatus
-	AirStatus: IMOSObjectAirStatus
+	Status?: IMOSObjectStatus
+	AirStatus?: IMOSObjectAirStatus
 	Paths: Array<IMOSObjectPath>
-	CreatedBy: MosString128
-	Created: MosTime
+	CreatedBy?: MosString128
+	Created?: MosTime
 	ChangedBy?: MosString128 // if not present, defaults to CreatedBy
 	Changed?: MosTime // if not present, defaults to Created
 	Description?: any // xml json
 	MosExternalMetaData?: Array<IMOSExternalMetaData>
+	MosItemEditorProgID?: MosString128
 }
 
 export enum IMOSObjectType {
 	STILL = 'STILL',
 	AUDIO = 'AUDIO',
-	VIDEO = 'VIDEO'
+	VIDEO = 'VIDEO',
+	OTHER = 'OTHER' // unknown/not speficied
 }
 
 export enum IMOSObjectStatus {

--- a/src/api.ts
+++ b/src/api.ts
@@ -185,7 +185,7 @@ export interface IMOSROFullStoryBodyItem {
 export interface IMOSItem {
 	ID: MosString128
 	Slug?: MosString128
-	ItemSlug?: MosString128
+	ObjectSlug?: MosString128
 	ObjectID: MosString128
 	MOSID: string
 	mosAbstract?: string

--- a/src/connection/mosSocketClient.ts
+++ b/src/connection/mosSocketClient.ts
@@ -2,16 +2,11 @@ import { EventEmitter } from 'events'
 import { Socket } from 'net'
 import { SocketConnectionEvent } from './socketConnection'
 import { MosMessage } from '../mosModel/MosMessage'
-import * as parser from 'xml2json'
+import { xml2js } from '../utils/Utils'
 const iconv = require('iconv-lite')
 
 export type CallBackFunction = (err: any, data: object) => void
 
-const parseOptions: any = {
-	'object': true,
-	coerce: true,
-	trim: true
-}
 interface QueueMessage {
 	time: number
 	msg: MosMessage
@@ -297,11 +292,11 @@ export class MosSocketClient extends EventEmitter {
 			// console.log(first === firstMatch, last === lastMatch, last, lastMatch)
 			if (first === firstMatch && last === lastMatch) {
 				// Data ready to be parsed:
-				parsedData = parser.toJson(messageString, parseOptions)
+				parsedData = xml2js(messageString)// , { compact: true, trim: true, nativeType: true })
 				this.dataChunks = ''
 			} else if (last === lastMatch) {
 				// Last chunk, ready to parse with saved data:
-				parsedData = parser.toJson(this.dataChunks + messageString, parseOptions)
+				parsedData = xml2js(this.dataChunks)// , { compact: true, trim: true, nativeType: true })
 				this.dataChunks = ''
 			} else if (first === firstMatch) {
 				// Chunk, save for later:
@@ -312,6 +307,7 @@ export class MosSocketClient extends EventEmitter {
 			}
 			// let parsedData: any = parser.toJson(messageString, )
 			if (parsedData) {
+				// console.log(parsedData, newParserData)
 				let messageId = parsedData.mos.messageID
 				if (messageId) {
 					if (this._sentMessage) {

--- a/src/dataTypes/mosString128.ts
+++ b/src/dataTypes/mosString128.ts
@@ -4,7 +4,11 @@ export class MosString128 {
 
 	/** */
 	constructor (str: any) {
-		this.string = '' + str + ''
+		if (typeof str === 'object' && str.text) {
+			this.string = str.text
+		} else {
+			this.string = '' + str + ''
+		}
 	}
 	/** */
 	toString (): string {
@@ -12,8 +16,12 @@ export class MosString128 {
 	}
 
 	/** */
-	set string (str: string) {
-		this._str = str
+	set string (str: string | { text: string, type: string }) {
+		if (typeof str === 'object' && str.type === 'text') {
+			this._str = str.text
+		} else {
+			this._str = '' + str + ''
+		}
 		this._validate()
 	}
 

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -425,6 +425,18 @@ export namespace Parser {
 		})
 		console.log('xml2Body', body)
 		*/
+		if (xml.elements && Array.isArray(xml.elements)) {
+			for (const item of xml.elements) {
+				let bodyItem: IMOSROFullStoryBodyItem = {
+					Type: item.name || item.type,
+					Content: item
+				}
+				if (item.name === 'storyItem') {
+					bodyItem.Content = xml2Item(item)
+				}
+				body.push(bodyItem)
+			}
+		}
 		// Temporary implementation:
 		if (xml.storyItem) {
 			let items: Array<any> = xml.storyItem

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -11,8 +11,7 @@ import {
 	IMOSROAckObject,
 	IMOSObject,
 	IMOSROFullStory,
-	IMOSROFullStoryBodyItem,
-	IMOSObjectType
+	IMOSROFullStoryBodyItem
 } from '../api'
 import { IMOSExternalMetaData } from '../dataTypes/mosExternalMetaData'
 import { MosString128 } from '../dataTypes/mosString128'
@@ -257,14 +256,6 @@ export namespace Parser {
 			})
 		}
 		return xmlItem
-	}
-	function isEmpty (obj: object) {
-		for (let key in obj) {
-			if (obj.hasOwnProperty(key)) {
-				return false
-			}
-		}
-		return true
 	}
 	function fixPayload (obj: any): any {
 		if (typeof obj === 'object') {

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -447,10 +447,10 @@ export namespace Parser {
 		if (xml.elements && Array.isArray(xml.elements)) {
 			for (const item of xml.elements) {
 				let bodyItem: IMOSROFullStoryBodyItem = {
-					Type: item.name || item.type,
+					Type: item.$name || item.$type,
 					Content: item
 				}
-				if (item.name === 'storyItem') {
+				if (item.$name === 'storyItem') {
 					bodyItem.Content = xml2Item(item)
 				}
 				body.push(bodyItem)

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -196,8 +196,8 @@ export namespace Parser {
 			if (type) {
 				paths.push({
 					Type: type,
-					Description: xmlPath.o.techDescription,
-					Target: xmlPath.o.$t
+					Description: xmlPath.o.techDescription || xmlPath.o.attributes.techDescription,
+					Target: xmlPath.o.text || xmlPath.o.$t
 				})
 			}
 		})

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -17,7 +17,8 @@ import { IMOSExternalMetaData } from '../dataTypes/mosExternalMetaData'
 import { MosString128 } from '../dataTypes/mosString128'
 import { MosTime } from '../dataTypes/mosTime'
 import { MosDuration } from '../dataTypes/mosDuration'
-import * as parser from 'xml2json'
+// import * as parser from 'xml2json'
+import { js2xml } from 'xml-js'
 import { ROAck } from '../mosModel/ROAck'
 
 function isEmpty (obj: any) {
@@ -269,14 +270,16 @@ export namespace Parser {
 		})
 	}
 	export function metaData2xml (md: IMOSExternalMetaData): XMLBuilder.XMLElementOrXMLNode {
-		let xmlMD = XMLBuilder.create('mosExternalMetadata')
+		// let xmlMD = XMLBuilder.create('mosExternalMetadata')
 
-		if (md.MosScope) xmlMD.ele('mosScope', {}, md.MosScope)
-		xmlMD.ele('mosSchema', {}, md.MosSchema)
+		// if (md.MosScope) xmlMD.ele('mosScope', {}, md.MosScope)
+		// xmlMD.ele('mosSchema', {}, md.MosSchema)
 
-		let payload = parser.toXml(md.MosPayload)  // TODO: implement this properly, convert to xml
-		xmlMD.ele('mosPayload', {}, payload)
-		return xmlMD
+		// let payload = parser.toXml(md.MosPayload)  // TODO: implement this properly, convert to xml
+		let payload = js2xml({ mosExternalMetadata: md }, { compact: true })
+		return XMLBuilder.create(payload)
+		// xmlMD.ele('mosPayload', {}, payload)
+		// return xmlMD
 	}
 	export function xml2IDs (xml: any): Array<MosString128> {
 		let arr: Array<MosString128> = []

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -17,8 +17,6 @@ import { IMOSExternalMetaData } from '../dataTypes/mosExternalMetaData'
 import { MosString128 } from '../dataTypes/mosString128'
 import { MosTime } from '../dataTypes/mosTime'
 import { MosDuration } from '../dataTypes/mosDuration'
-// import * as parser from 'xml2json'
-import { js2xml } from 'xml-js'
 import { ROAck } from '../mosModel/ROAck'
 
 function isEmpty (obj: any) {
@@ -276,8 +274,8 @@ export namespace Parser {
 		// xmlMD.ele('mosSchema', {}, md.MosSchema)
 
 		// let payload = parser.toXml(md.MosPayload)  // TODO: implement this properly, convert to xml
-		let payload = js2xml({ mosExternalMetadata: md }, { compact: true })
-		return XMLBuilder.create(payload)
+		// let payload = js2xml({ mosExternalMetadata: md }, { compact: true })
+		return XMLBuilder.create({ mosExternalMetadata: md })
 		// xmlMD.ele('mosPayload', {}, payload)
 		// return xmlMD
 	}

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -192,7 +192,7 @@ export namespace Parser {
 			} else if (xmlPath.key === 'objMetadataPath') {
 				type = IMOSObjectPathType.METADATA_PATH
 			}
-			if (type) {
+			if (type && Object.keys(xmlPath.o).length > 0) {
 				paths.push({
 					Type: type,
 					Description: xmlPath.o.techDescription || xmlPath.o.attributes.techDescription,

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -90,7 +90,7 @@ export function xml2js (messageString: string): object {
 						delete element.elements
 					} else if (names.length === namesSet.size) {
 						for (const childEl of element.elements) {
-							if (childEl.type && childEl.type === 'text' && (Object.keys(childEl).length < 4 || (!childEl.name && Object.keys(childEl).length < 3))) {
+							if (childEl.type && childEl.type === 'text' && (Object.keys(childEl).length <= 3 || (!childEl.name && Object.keys(childEl).length < 3))) {
 								if (!childEl.text) {
 									element.text = childEl.text
 								}
@@ -113,7 +113,7 @@ export function xml2js (messageString: string): object {
 						const holder: {[key: string]: any} = {}
 						for (let childEl of element.elements) {
 							const name = childEl.name
-							if (childEl.type === 'text' && Object.keys(childEl).length < 4) {
+							if (childEl.type === 'text' && Object.keys(childEl).length <= 3) {
 								childEl = childEl.text
 							} else if (childEl.attributes) {
 								for (const key in childEl.attributes) {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -10,11 +10,13 @@ export function pad (n: string, width: number, z?: string): string {
 export function xml2js (messageString: string): object {
 	let object = xmlParser(messageString, { compact: false, trim: true, nativeType: true })
 	// common tags we typically want to know the order of the contents of:
-	const orderedTags = new Set([ 'mosAbstract', 'description', 'p', 'em', 'span', 'h1', 'h2', 'i', 'b' ])
+	const orderedTags = new Set([ 'storyBody', 'storyItem', 'mosAbstract', 'description', 'p', 'em', 'span', 'h1', 'h2', 'i', 'b' ])
 
 	const concatChildrenAndTraverseObject = (element: {[key: string]: any }) => {
 		if (element.elements) {
 			if (element.elements.length === 1) {
+				concatChildrenAndTraverseObject(element.elements[0])
+
 				const childEl = element.elements[0]
 				const name = childEl.name || childEl.type || 'unknownElement'
 				if (childEl.type && childEl.type === 'text') {
@@ -30,7 +32,6 @@ export function xml2js (messageString: string): object {
 					)
 				}
 				delete element.elements
-				concatChildrenAndTraverseObject(childEl)
 				if (childEl.type === 'text') {
 					element[name] = childEl.text
 					if (childEl.attributes) {
@@ -45,83 +46,86 @@ export function xml2js (messageString: string): object {
 					concatChildrenAndTraverseObject(childEl)
 				}
 
-				let names: Array<string> = element.elements.map((obj: { name?: string, type?: string }) => obj.name || obj.type || 'unknownElement')
-				let namesSet = new Set(names)
-				if ((namesSet.size === 1 && names.length !== 1) && !namesSet.has('type') && !namesSet.has('name')) {
-					// make array compact:
-					const array: any = []
-					for (const childEl of element.elements) {
-						if (childEl.type && childEl.type === 'text') {
-							if (Object.keys(childEl).length > 2) {
-								array.push(childEl)
-							} else if (childEl.attributes) {
-								childEl.attributes.text = childEl.text
-								array.push(childEl.attributes)
+				if (!orderedTags.has(element.name)) {
+					// console.log(element)
+					let names: Array<string> = element.elements.map((obj: { name?: string, type?: string }) => obj.name || obj.type || 'unknownElement')
+					let namesSet = new Set(names)
+					if ((namesSet.size === 1 && names.length !== 1) && !namesSet.has('type') && !namesSet.has('name')) {
+						// make array compact:
+						const array: any = []
+						for (const childEl of element.elements) {
+							if (childEl.type && childEl.type === 'text') {
+								if (Object.keys(childEl).length > 2) {
+									array.push(childEl)
+								} else if (childEl.attributes) {
+									childEl.attributes.text = childEl.text
+									array.push(childEl.attributes)
+								} else {
+									array.push(childEl.text)
+								}
 							} else {
-								array.push(childEl.text)
+								if (childEl.type) delete childEl.type
+								if (childEl.name) delete childEl.name
+								if (Object.keys(childEl).length > 1) {
+									// might contain something useful like attributes
+									if (childEl.attributes) {
+										for (const key in childEl.attributes) {
+											childEl[key] = childEl.attributes[key]
+										}
+										delete childEl.attributes
+									}
+									array.push(childEl)
+								} else {
+									array.push(childEl[Object.keys(childEl)[0]])
+								}
 							}
-						} else {
-							if (childEl.type) delete childEl.type
-							if (childEl.name) delete childEl.name
-							if (Object.keys(childEl).length > 1) {
-								// might contain something useful like attributes
+						}
+						element[names[0]] = array
+						delete element.elements
+					} else if (names.length === namesSet.size) {
+						for (const childEl of element.elements) {
+							if (childEl.type && childEl.type === 'text' && (Object.keys(childEl).length < 4 || (!childEl.name && Object.keys(childEl).length < 3))) {
+								if (!childEl.text) {
+									element.text = childEl.text
+								}
+								element[childEl.name] = childEl.text
+							} else {
 								if (childEl.attributes) {
 									for (const key in childEl.attributes) {
 										childEl[key] = childEl.attributes[key]
 									}
 									delete childEl.attributes
 								}
-								array.push(childEl)
-							} else {
-								array.push(childEl[Object.keys(childEl)[0]])
+								const name = childEl.name || childEl.type || 'unknownEl'
+								if (childEl.type) delete childEl.type
+								if (childEl.name) delete childEl.name
+								element[name] = childEl
 							}
 						}
-					}
-					element[names[0]] = array
-					delete element.elements
-				} else if (names.length === namesSet.size && !orderedTags.has(element.name)) {
-					for (const childEl of element.elements) {
-						if (childEl.type && childEl.type === 'text' && (Object.keys(childEl).length < 4 || (!childEl.name && Object.keys(childEl).length < 3))) {
-							if (!childEl.text) {
-								element.text = childEl.text
-							}
-							element[childEl.name] = childEl.text
-						} else {
-							if (childEl.attributes) {
+						delete element.elements
+					} else if (names.length !== namesSet.size) {
+						const holder: {[key: string]: any} = {}
+						for (let childEl of element.elements) {
+							const name = childEl.name
+							if (childEl.type === 'text' && Object.keys(childEl).length < 4) {
+								childEl = childEl.text
+							} else if (childEl.attributes) {
 								for (const key in childEl.attributes) {
 									childEl[key] = childEl.attributes[key]
 								}
 								delete childEl.attributes
 							}
-							const name = childEl.name || childEl.type || 'unknownEl'
-							if (childEl.type) delete childEl.type
-							if (childEl.name) delete childEl.name
-							element[name] = childEl
-						}
-					}
-					delete element.elements
-				} else if (names.length !== namesSet.size && !orderedTags.has(element.name)) {
-					const holder: {[key: string]: any} = {}
-					for (let childEl of element.elements) {
-						const name = childEl.name
-						if (childEl.type === 'text' && Object.keys(childEl).length < 4) {
-							childEl = childEl.text
-						} else if (childEl.attributes) {
-							for (const key in childEl.attributes) {
-								childEl[key] = childEl.attributes[key]
+							if (holder[name]) {
+								holder[name].push(childEl)
+							} else {
+								holder[name] = [ childEl ]
 							}
-							delete childEl.attributes
 						}
-						if (holder[name]) {
-							holder[name].push(childEl)
-						} else {
-							holder[name] = [ childEl ]
+						for (const key in holder) {
+							element[key] = holder[key].length > 1 ? holder[key] : holder[key][0]
 						}
+						delete element.elements
 					}
-					for (const key in holder) {
-						element[key] = holder[key].length > 1 ? holder[key] : holder[key][0]
-					}
-					delete element.elements
 				}
 			}
 		}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,6 +1,104 @@
+import { xml2js as xmlParser } from 'xml-js'
+
 /** */
 export function pad (n: string, width: number, z?: string): string {
 	z = z || '0'
 	n = n + ''
 	return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n
+}
+
+export function xml2js (messageString: string): object {
+	let object = xmlParser(messageString, { compact: false, trim: true, nativeType: true })
+	// common tags we typically want to know the order of the contents of:
+	const orderedTags = new Set([ 'mosAbstract', 'description', 'p', 'em', 'span', 'h1', 'h2', 'i', 'b' ])
+
+	const concatChildrenAndTraverseObject = (element: {[key: string]: any }) => {
+		if (element.elements) {
+			if (element.elements.length === 1) {
+				const childEl = element.elements[0]
+				const name = childEl.name || childEl.type || 'unknownElement'
+				if (childEl.type && childEl.type === 'text') {
+					element.type = 'text'
+					Object.defineProperty(element, 'text', Object.getOwnPropertyDescriptor(childEl, 'text')!)
+					delete childEl.attributes
+				} else {
+					delete childEl.name
+					delete childEl.type
+					Object.defineProperty(
+						element,
+						name,
+						Object.getOwnPropertyDescriptor(element.elements, 0)!
+					)
+				}
+				delete element.elements
+				concatChildrenAndTraverseObject(childEl)
+				if (childEl.type === 'text' && !childEl.attributes) {
+					element[name] = childEl.text
+				}
+			} else if (element.elements.length > 1) {
+				for (const childEl of element.elements) {
+					concatChildrenAndTraverseObject(childEl)
+				}
+
+				let names: Array<string> = element.elements.map((obj: { name?: string, type?: string }) => obj.name || obj.type || 'unknownElement')
+				let namesSet = new Set(names)
+				if ((namesSet.size === 1 && names.length !== 1) && !namesSet.has('type') && !namesSet.has('name')) {
+					// make array compact:
+					const array: any = []
+					for (const childEl of element.elements) {
+						if (childEl.type && childEl.type === 'text') {
+							if (childEl.text) array.push(childEl.text)
+							if (childEl.text) array.push(childEl.text)
+						} else {
+							if (childEl.type) delete childEl.type
+							if (childEl.name) delete childEl.name
+							if (Object.keys(childEl).length > 1) {
+								// might contain something useful like attributes
+								array.push(childEl)
+							} else {
+								array.push(childEl[Object.keys(childEl)[0]])
+							}
+						}
+					}
+					element[names[0]] = array
+					delete element.elements
+				} else if (names.length === namesSet.size && !orderedTags.has(element.name)) {
+					for (const childEl of element.elements) {
+						if (childEl.type && childEl.type === 'text' && !childEl.attributes) {
+							if (!childEl.text) {
+								element.text = childEl.text
+							}
+							element[childEl.name] = childEl.text
+						} else {
+							const name = childEl.name || childEl.type || 'unknownEl'
+							if (childEl.type) delete childEl.type
+							if (childEl.name) delete childEl.name
+							element[name] = childEl
+						}
+					}
+					delete element.elements
+				} else if (names.length !== namesSet.size && !orderedTags.has(element.name)) {
+					const holder: {[key: string]: any} = {}
+					for (let childEl of element.elements) {
+						const name = childEl.name
+						if (childEl.type === 'text') {
+							childEl = childEl.text
+						}
+						if (holder[name]) {
+							holder[name].push(childEl)
+						} else {
+							holder[name] = [ childEl ]
+						}
+					}
+					for (const key in holder) {
+						element[key] = holder[key].length > 1 ? holder[key] : holder[key][0]
+					}
+					delete element.elements
+				}
+			}
+		}
+	}
+	concatChildrenAndTraverseObject(object)
+
+	return object
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -15,7 +15,7 @@ export function xml2js (messageString: string): object {
 	/**
 	 * Doing a post-order tree traversal we try to make the objectified tree as compact as possible.
 	 * Whenever we find an "orderedTag" we keep the order of it's children.
-	 * 
+	 *
 	 * ps: post-order means we make a node's children as compact as possible first, and then try to make
 	 * that node compact.
 	 */

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -10,8 +10,15 @@ export function pad (n: string, width: number, z?: string): string {
 export function xml2js (messageString: string): object {
 	let object = xmlParser(messageString, { compact: false, trim: true, nativeType: true })
 	// common tags we typically want to know the order of the contents of:
-	const orderedTags = new Set([ 'storyBody', 'storyItem', 'mosAbstract', 'description', 'p', 'em', 'span', 'h1', 'h2', 'i', 'b' ])
+	const orderedTags = new Set([ 'storyBody', 'mosAbstract', 'description', 'p', 'em', 'span', 'h1', 'h2', 'i', 'b' ])
 
+	/**
+	 * Doing a post-order tree traversal we try to make the objectified tree as compact as possible.
+	 * Whenever we find an "orderedTag" we keep the order of it's children.
+	 * 
+	 * ps: post-order means we make a node's children as compact as possible first, and then try to make
+	 * that node compact.
+	 */
 	const concatChildrenAndTraverseObject = (element: {[key: string]: any }) => {
 		if (element.elements) {
 			if (element.elements.length === 1) {
@@ -46,8 +53,7 @@ export function xml2js (messageString: string): object {
 					concatChildrenAndTraverseObject(childEl)
 				}
 
-				if (!orderedTags.has(element.name)) {
-					// console.log(element)
+				if (!orderedTags.has(element.name)) { // if the element name is contained in the set of orderedTag names we don't make it any more compact
 					let names: Array<string> = element.elements.map((obj: { name?: string, type?: string }) => obj.name || obj.type || 'unknownElement')
 					let namesSet = new Set(names)
 					if ((namesSet.size === 1 && names.length !== 1) && !namesSet.has('type') && !namesSet.has('name')) {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -139,7 +139,6 @@ export function xml2js (messageString: string): object {
 						}
 						delete element.elements
 					}
-				} else {
 				}
 			}
 		}

--- a/src/utils/__tests__/Utils.spec.ts
+++ b/src/utils/__tests__/Utils.spec.ts
@@ -1,0 +1,18 @@
+import {
+	xml2js
+} from '../Utils'
+test('xml2js', () => {
+	let o = xml2js(`
+<mos>
+<p>Hello and welcome</p>
+<mosObject>[name sign]</mosObject>
+<p>This is a extra broadcast bla bla</p>
+<mosObject></mosObject>
+<p>Let's look at this video:</p>
+<mosObject>[video]</mosObject>
+</mos>
+	`)
+	// console.log(o.mos)
+	expect(o).toBeTruthy()
+	// expect(o.mos).toBeTruthy()
+})

--- a/src/utils/__tests__/Utils.spec.ts
+++ b/src/utils/__tests__/Utils.spec.ts
@@ -2,7 +2,7 @@ import {
 	xml2js
 } from '../Utils'
 test('xml2js', () => {
-	let o = xml2js(`
+	let o: any = xml2js(`
 <roStorySend>
 	<storyBody>
 		<p>Hello and welcome</p>
@@ -17,14 +17,15 @@ test('xml2js', () => {
 	`)
 	// console.log(o.roStorySend.storyBody)
 	expect(o).toBeTruthy()
-	expect(o.roStorySend.storyBody).toMatchObject({ elements: 
-         [ { type: 'text', name: 'p', text: 'Hello and welcome' },
-           { type: 'text', name: 'mosObject', text: '[name sign]' },
-           { type: 'text',
-             name: 'p',
-             text: 'This is a extra broadcast bla bla' },
-           { type: 'element', name: 'mosObject' },
-           { type: 'text', name: 'p', text: 'Let\'s look at this video:' },
-           { type: 'text', name: 'mosObject', text: '[video]' } ] })
-	// expect(o.mos).toBeTruthy()
+	expect(o.roStorySend.storyBody).toMatchObject({
+		elements: [
+			{ type: 'text', name: 'p', text: 'Hello and welcome' },
+			{ type: 'text', name: 'mosObject', text: '[name sign]' },
+			{ type: 'text', name: 'p', text: 'This is a extra broadcast bla bla' },
+			{ type: 'element', name: 'mosObject' },
+			{ type: 'text', name: 'p', text: 'Let\'s look at this video:' },
+			{ type: 'text', name: 'mosObject', text: '[video]' }
+		]
+	})
+		// expect(o.mos).toBeTruthy()
 })

--- a/src/utils/__tests__/Utils.spec.ts
+++ b/src/utils/__tests__/Utils.spec.ts
@@ -15,17 +15,37 @@ test('xml2js', () => {
 	</storyBody>
 </roStorySend>
 	`)
-	// console.log(o.roStorySend.storyBody)
+	// console.log('o.roStorySend', o.roStorySend)
 	expect(o).toBeTruthy()
 	expect(o.roStorySend.storyBody).toMatchObject({
 		elements: [
-			{ type: 'text', name: 'p', text: 'Hello and welcome' },
-			{ type: 'text', name: 'mosObject', text: '[name sign]' },
-			{ type: 'text', name: 'p', text: 'This is a extra broadcast bla bla' },
-			{ type: 'element', name: 'mosObject' },
-			{ type: 'text', name: 'p', text: 'Let\'s look at this video:' },
-			{ type: 'text', name: 'mosObject', text: '[video]' }
+			{ $type: 'text', $name: 'p', text: 'Hello and welcome' },
+			{ $type: 'text', $name: 'mosObject', text: '[name sign]' },
+			{ $type: 'text', $name: 'p', text: 'This is a extra broadcast bla bla' },
+			{ $type: 'element', $name: 'mosObject' },
+			{ $type: 'text', $name: 'p', text: 'Let\'s look at this video:' },
+			{ $type: 'text', $name: 'mosObject', text: '[video]' }
 		]
+	})
+		// expect(o.mos).toBeTruthy()
+})
+
+test('xml2js with "name" element', () => {
+	let o: any = xml2js(`
+<template>
+	<name>52_headline</name>
+	<channel>gfx1</channel>
+	<layer>super</layer>
+	<system>html</system>
+</template>
+	`)
+	// console.log('o', o)
+	// expect(o).toBeTruthy()
+	expect(o.template).toMatchObject({
+		name: '52_headline',
+		channel: 'gfx1',
+		layer: 'super',
+		system: 'html'
 	})
 		// expect(o.mos).toBeTruthy()
 })

--- a/src/utils/__tests__/Utils.spec.ts
+++ b/src/utils/__tests__/Utils.spec.ts
@@ -15,7 +15,7 @@ test('xml2js', () => {
 	</storyBody>
 </roStorySend>
 	`)
-	console.log(o.roStorySend.storyBody)
+	// console.log(o.roStorySend.storyBody)
 	expect(o).toBeTruthy()
 	expect(o.roStorySend.storyBody).toMatchObject({ elements: 
          [ { type: 'text', name: 'p', text: 'Hello and welcome' },

--- a/src/utils/__tests__/Utils.spec.ts
+++ b/src/utils/__tests__/Utils.spec.ts
@@ -3,16 +3,28 @@ import {
 } from '../Utils'
 test('xml2js', () => {
 	let o = xml2js(`
-<mos>
-<p>Hello and welcome</p>
-<mosObject>[name sign]</mosObject>
-<p>This is a extra broadcast bla bla</p>
-<mosObject></mosObject>
-<p>Let's look at this video:</p>
-<mosObject>[video]</mosObject>
-</mos>
+<roStorySend>
+	<storyBody>
+		<p>Hello and welcome</p>
+		<mosObject>[name sign]</mosObject>
+		<p>This is a extra broadcast bla bla</p>
+		<mosObject>
+		</mosObject>
+		<p>Let's look at this video:</p>
+		<mosObject>[video]</mosObject>
+	</storyBody>
+</roStorySend>
 	`)
-	// console.log(o.mos)
+	console.log(o.roStorySend.storyBody)
 	expect(o).toBeTruthy()
+	expect(o.roStorySend.storyBody).toMatchObject({ elements: 
+         [ { type: 'text', name: 'p', text: 'Hello and welcome' },
+           { type: 'text', name: 'mosObject', text: '[name sign]' },
+           { type: 'text',
+             name: 'p',
+             text: 'This is a extra broadcast bla bla' },
+           { type: 'element', name: 'mosObject' },
+           { type: 'text', name: 'p', text: 'Let\'s look at this video:' },
+           { type: 'text', name: 'mosObject', text: '[video]' } ] })
 	// expect(o.mos).toBeTruthy()
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4622,6 +4622,12 @@ xdg-trashdir@^2.1.1:
     user-home "^2.0.0"
     xdg-basedir "^2.0.0"
 
+xml-js@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.4.tgz#fcf9fdc9fb6d691122a02fe5a55c30f84d93ab90"
+  dependencies:
+    sax "^1.2.4"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,10 +83,6 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/xml2json@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@types/xml2json/-/xml2json-0.10.0.tgz#e967e1ed62ce7a67266d739d78486cc57e125697"
-
 "@types/xmlbuilder@^0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/xmlbuilder/-/xmlbuilder-0.0.32.tgz#f3107c16a05311ed117af1051c061cfbd8178309"
@@ -499,10 +495,6 @@ bcrypt-pbkdf@^1.0.0:
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
-
-bindings@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
 
 block-stream@*:
   version "0.0.9"
@@ -1838,13 +1830,9 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoek@4.x.x, hoek@^4.2.1:
+hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-
-hoek@5.x.x:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -2146,12 +2134,6 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isemail@3.x.x:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.1.tgz#e8450fe78ff1b48347db599122adcd0668bd92b5"
-  dependencies:
-    punycode "2.x.x"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2488,14 +2470,6 @@ jest@^22.4.2:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^22.4.2"
-
-joi@^13.1.2:
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-13.1.2.tgz#b2db260323cc7f919fafa51e09e2275bd089a97e"
-  dependencies:
-    hoek "5.x.x"
-    isemail "3.x.x"
-    topo "3.x.x"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -2929,10 +2903,6 @@ nan@^2.3.0:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
 
-nan@^2.3.5:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -2946,13 +2916,6 @@ nlf@^1.4.2:
     compare-versions "3.0.0"
     glob-all "3.1.0  "
     read-installed "4.0.3"
-
-node-expat@^2.3.15:
-  version "2.3.16"
-  resolved "https://registry.yarnpkg.com/node-expat/-/node-expat-2.3.16.tgz#adb22174e1aaa5305996bd5b1aa6f2c8d5c0f239"
-  dependencies:
-    bindings "^1.2.1"
-    nan "^2.3.5"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3410,13 +3373,13 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-punycode@2.x.x, punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
-
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 q@^1.4.1, q@^1.5.1:
   version "1.5.1"
@@ -4211,12 +4174,6 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-topo@3.x.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
-  dependencies:
-    hoek "5.x.x"
-
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
@@ -4625,14 +4582,6 @@ xml-js@^1.6.4:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
-
-xml2json@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/xml2json/-/xml2json-0.11.2.tgz#70ddd234fd7818312cc58455cab8457b5bcc7c52"
-  dependencies:
-    hoek "^4.2.1"
-    joi "^13.1.2"
-    node-expat "^2.3.15"
 
 xmlbuilder@^9.0.7:
   version "9.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,12 +83,6 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/xml2js@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.2.tgz#a4b84b3879ffd4710953fd92cabfde9a8a4e8456"
-  dependencies:
-    "@types/node" "*"
-
 "@types/xml2json@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@types/xml2json/-/xml2json-0.10.0.tgz#e967e1ed62ce7a67266d739d78486cc57e125697"
@@ -3817,7 +3811,7 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -4632,13 +4626,6 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xml2js@^0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
-
 xml2json@^0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/xml2json/-/xml2json-0.11.2.tgz#70ddd234fd7818312cc58455cab8457b5bcc7c52"
@@ -4647,7 +4634,7 @@ xml2json@^0.11.2:
     joi "^13.1.2"
     node-expat "^2.3.15"
 
-xmlbuilder@^9.0.7, xmlbuilder@~9.0.1:
+xmlbuilder@^9.0.7:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Keeps the order of tags on certain mos elements


* **What is the current behavior?** (You can also link to an open issue here)
```
<p>Hello and welcome</p>
<mosObject>[name sign]</mosObject>
<p>This is a extra broadcast bla bla</p>
<mosObject></mosObject>
<p>Let's look at this video:</p>
<mosObject>[video]</mosObject>
```
Becomes
```
{
  p: ['Hello and welcome', 'This is a extra broadcast bla bla', 'let\'s look at this video']
  mosObject: ['name sign', ' ', 'video']
}
```


* **What is the new behavior (if this is a feature change)?**
Structure becomes
```
{
  elements: [
    { name: 'p', text: 'Hello and welcome' }
    { name: 'mosObject', text: 'name sign' }
    { name: 'p', text: 'This is a extra broadcast bla bla' }
    { name: 'mosObject', text: ' ' }
    { name: 'p', text: 'let\'s look at this video' }
    { name: 'mosObject', text: 'video' }
  ]
}
```

* **Other information**:
Removed now unused dependencies: xml2js and xml2json
