### PR TITLE
Buddy Server / Failover to secondary

### DIFF
--- a/src/MosConnection.ts
+++ b/src/MosConnection.ts
@@ -244,7 +244,7 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 	): MosDevice {
 		let id0 = myMosID + '_' + theirMosId0
 		let id1 = (theirMosId1 ? myMosID + '_' + theirMosId1 : null)
-		let mosDevice = new MosDevice(id0, id1, this._conf, primary, secondary)
+		let mosDevice = new MosDevice(id0, id1, this._conf, primary, secondary, this._conf.offspecFailover)
 
 		// Add mosDevice to register:
 		if (this._mosDevices[id0]) {

--- a/src/MosDevice.ts
+++ b/src/MosDevice.ts
@@ -841,6 +841,9 @@ export class MosDevice implements IMOSDevice {
 	private executeCommand (message: MosMessage, resend?: boolean): Promise<any> {
 		if (this._currentConnection) {
 			console.log('exec command', message)
+			if (!this._currentConnection.connected) {
+				return this.switchConnections(message)
+			}
 			return this._currentConnection.executeCommand(message).catch((e) => {
 				console.log('errored', e)
 				if (this._primaryConnection && this._secondaryConnection && !resend) {
@@ -858,6 +861,7 @@ export class MosDevice implements IMOSDevice {
 		if (this._currentConnection && this._primaryConnection && this._secondaryConnection) {
 			console.log('swithcing conn')
 			this._currentConnection = this._currentConnection === this._primaryConnection ? this._secondaryConnection : this._primaryConnection
+			if (!this._currentConnection.connected) return Promise.reject('No connection available for failover')
 			let p
 			if (message) {
 				console.log('resending msg')
@@ -874,6 +878,6 @@ export class MosDevice implements IMOSDevice {
 			(this._currentConnection === this._primaryConnection ? this._secondaryConnection : this._primaryConnection).handOverQueue(this._currentConnection)
 			return p || Promise.resolve()
 		}
-		return Promise.reject()
+		return Promise.reject('No connection available for failover')
 	}
 }

--- a/src/MosDevice.ts
+++ b/src/MosDevice.ts
@@ -850,7 +850,12 @@ export class MosDevice implements IMOSDevice {
 			if (!this._currentConnection.connected) {
 				return this.switchConnections(message)
 			}
-			return this._currentConnection.executeCommand(message).catch((e) => {
+			return this._currentConnection.executeCommand(message).then((res) => {
+				if (res.mos.roAck && res.mos.roAck.roStatus === 'Buddy server cannot respond because main server is available') {
+					return Promise.reject('Buddy server cannot respond because main server is available')
+				}
+				return res
+			}).catch((e) => {
 				console.log('errored', e)
 				if (this._primaryConnection && this._secondaryConnection && !resend) {
 					return this.switchConnections(message)

--- a/src/MosDevice.ts
+++ b/src/MosDevice.ts
@@ -116,7 +116,8 @@ export class MosDevice implements IMOSDevice {
 		idSecondary: string | null,
 		connectionConfig: IConnectionConfig,
 		primaryConnection: NCSServerConnection | null,
-		secondaryConnection: NCSServerConnection | null
+		secondaryConnection: NCSServerConnection | null,
+		offSpecFailover?: boolean
 	) {
 		// this._id = new MosString128(connectionConfig.mosID).toString()
 		this._idPrimary = idPrimary
@@ -147,7 +148,12 @@ export class MosDevice implements IMOSDevice {
 		}
 		if (primaryConnection) {
 			this._primaryConnection = primaryConnection
-			this._primaryConnection.onConnectionChange(() => this.emitConnectionChange())
+			this._primaryConnection.onConnectionChange(() => {
+				this.emitConnectionChange()
+				if (offSpecFailover && this._currentConnection !== this._primaryConnection && this._primaryConnection!.connected) {
+					this.switchConnections() // and hope no current message goes lost
+				}
+			})
 		}
 		if (secondaryConnection) {
 			this._secondaryConnection = secondaryConnection

--- a/src/MosDevice.ts
+++ b/src/MosDevice.ts
@@ -151,7 +151,7 @@ export class MosDevice implements IMOSDevice {
 			this._primaryConnection.onConnectionChange(() => {
 				this.emitConnectionChange()
 				if (offSpecFailover && this._currentConnection !== this._primaryConnection && this._primaryConnection!.connected) {
-					this.switchConnections() // and hope no current message goes lost
+					this.switchConnections().catch(() => null) // and hope no current message goes lost
 				}
 			})
 		}
@@ -882,7 +882,9 @@ export class MosDevice implements IMOSDevice {
 						return this.switchConnections(message)
 					}
 					// @ts-ignore - following line will always resolve if called from here
-					this.switchConnections()
+					this.switchConnections().catch((e) => {
+						throw Error('e')
+					})
 					return Promise.reject(e)
 				})
 			}

--- a/src/__tests__/MosConnection.spec.ts
+++ b/src/__tests__/MosConnection.spec.ts
@@ -327,7 +327,6 @@ test('mos device secondary', async () => {
 	expect(SocketMock.instances[4].connectedHost).toEqual('192.168.0.2')
 	expect(SocketMock.instances[4].connectedPort).toEqual(10541)
 
-
 	// Prepare mock server response:
 	let mockReply = jest.fn((data) => {
 		let str = decode(data)

--- a/src/__tests__/MosConnection.spec.ts
+++ b/src/__tests__/MosConnection.spec.ts
@@ -288,6 +288,68 @@ describe('MosDevice: General', () => {
 
 	})
 })
+test('mos device secondary', async () => {
+	let mos = new MosConnection({
+		mosID: 'jestMOS',
+		acceptsConnections: true,
+		profiles: {
+			'0': true,
+			'1': true
+		}
+	})
+	expect(mos.acceptsConnections).toBe(true)
+	await mos.init()
+	expect(mos.isListening).toBe(true)
+
+	let mosDevice = await mos.connect({
+		primary: {
+			id: 'primary',
+			host: '192.168.0.1',
+			timeout: 200
+		},
+		secondary: {
+			id: 'secondary',
+			host: '192.168.0.2',
+			timeout: 200
+		}
+	})
+	expect(mosDevice).toBeTruthy()
+	expect(mosDevice.idPrimary).toEqual('jestMOS_primary')
+	// expect(mosDevice.secondaryId).toEqual('jestMOS_secondary')
+
+	expect(SocketMock.instances).toHaveLength(5)
+	expect(SocketMock.instances[1].connectedHost).toEqual('192.168.0.1')
+	expect(SocketMock.instances[1].connectedPort).toEqual(10540)
+	expect(SocketMock.instances[2].connectedHost).toEqual('192.168.0.1')
+	expect(SocketMock.instances[2].connectedPort).toEqual(10541)
+	expect(SocketMock.instances[3].connectedHost).toEqual('192.168.0.2')
+	expect(SocketMock.instances[3].connectedPort).toEqual(10540)
+	expect(SocketMock.instances[4].connectedHost).toEqual('192.168.0.2')
+	expect(SocketMock.instances[4].connectedPort).toEqual(10541)
+
+
+	// Prepare mock server response:
+	let mockReply = jest.fn((data) => {
+		let str = decode(data)
+		// console.log('mockReply', str)
+		let messageID = str.match(/<messageID>([^<]+)<\/messageID>/)[1]
+		let repl = getXMLReply(messageID, xmlData.mosObj)
+
+		// console.log('repl', repl)
+		return encode(repl)
+	})
+
+	// add reply to secondary server, causes timeout on primary:
+	SocketMock.instances[3].mockAddReply(mockReply)
+	let returnedObj: IMOSObject = await mosDevice.getMOSObject(xmlApiData.mosObj.ID)
+	expect(returnedObj).toBeTruthy()
+
+	// add reply to primary server, causes timeout on secondary:
+	SocketMock.instances[1].mockAddReply(mockReply)
+	returnedObj = await mosDevice.getMOSObject(xmlApiData.mosObj.ID)
+	expect(returnedObj).toBeTruthy()
+
+})
 describe('MosDevice: Basic functionality', () => {
 	test('init and connectionStatusChanged', async () => {
 		SocketMock.mockClear()

--- a/src/__tests__/MosDevice.spec.ts
+++ b/src/__tests__/MosDevice.spec.ts
@@ -194,13 +194,6 @@ describe('MosDevice: Profile 0', () => {
 			// SecondaryStatus: string // if not connected this will contain human-readable error-message
 		})
 
-		// @todo: add timeout test
-		// mock cause timeout
-		// expect(connectionStatusChanged).toHaveBeenCalledTimes(1)
-		// expect(connectionStatusChanged.mock.calls[0][0]).toMatchObject({PrimaryConnected: false})
-		await mosDevice.getAllMOSObjects().catch(() => null)
-		expect(false).toBe(true)
-
 		// Test proper dispose:
 		await mosDevice.dispose()
 

--- a/src/__tests__/MosDevice.spec.ts
+++ b/src/__tests__/MosDevice.spec.ts
@@ -42,6 +42,18 @@ let testoptions = {
 		timeout: 200
 	}
 }
+let testoptions2 = {
+	primary: {
+		id: 'mockServer',
+		host: '127.0.0.1',
+		timeout: 200
+	},
+	secondary: {
+		id: 'mockServer',
+		host: '127.0.0.2',
+		timeout: 200
+	}
+}
 
 // describe('MosDevice', async () => {
 	// // @todo: @ojna: fix this?
@@ -119,6 +131,75 @@ describe('MosDevice: Profile 0', () => {
 		// mock cause timeout
 		// expect(connectionStatusChanged).toHaveBeenCalledTimes(1)
 		// expect(connectionStatusChanged.mock.calls[0][0]).toMatchObject({PrimaryConnected: false})
+
+		// Test proper dispose:
+		await mosDevice.dispose()
+
+		expect(connMocks[1].destroy).toHaveBeenCalledTimes(1)
+		expect(connMocks[2].destroy).toHaveBeenCalledTimes(1)
+	})
+	test('buddy failover', async () => {
+		let mos = new MosConnection(testconfig)
+		await mos.init()
+		let mosDevice: MosDevice = await mos.connect(testoptions2)
+
+		expect(mosDevice).toBeTruthy()
+
+		expect(SocketMock.instances).toHaveLength(5)
+		// console.log(SocketMock.instances)
+		let connMocks = SocketMock.instances
+		// expect(connMocks[0].connect).toHaveBeenCalledTimes(1)
+		// expect(connMocks[0].connect.mock.calls[0][0]).toEqual(10540)
+		// expect(connMocks[0].connect.mock.calls[0][1]).toEqual('127.0.0.1')
+		expect(connMocks[1].connect).toHaveBeenCalledTimes(1)
+		expect(connMocks[1].connect.mock.calls[0][0]).toEqual(10540)
+		expect(connMocks[1].connect.mock.calls[0][1]).toEqual('127.0.0.1')
+		expect(connMocks[2].connect).toHaveBeenCalledTimes(1)
+		expect(connMocks[2].connect.mock.calls[0][0]).toEqual(10541)
+		expect(connMocks[2].connect.mock.calls[0][1]).toEqual('127.0.0.1')
+
+		let connectionStatusChanged = jest.fn()
+
+		mosDevice.onConnectionChange((connectionStatus: IMOSConnectionStatus) => {
+			connectionStatusChanged(connectionStatus)
+		})
+
+		// expect(connectionStatusChanged).toHaveBeenCalledTimes(1) // dunno if it really should have been called, maybe remove
+		// jest.runOnlyPendingTimers()
+		await delay(10) // to allow for async timers & events to triggered
+		// console.log('-----------')
+
+		expect(mosDevice.getConnectionStatus()).toMatchObject({
+			PrimaryConnected: true,
+			PrimaryStatus: '', // if not connected this will contain human-readable error-message
+			SecondaryConnected: true
+			// SecondaryStatus: string // if not connected this will contain human-readable error-message
+		})
+
+		connectionStatusChanged.mockClear()
+
+		// console.log('----------- test timeout')
+		// test timeout:
+		connMocks[1].setReplyToHeartBeat(false)
+		connMocks[2].setReplyToHeartBeat(true)
+
+		// jest.runOnlyPendingTimers() // allow for heartbeats to be sent
+		// jest.runOnlyPendingTimers() // allow for heartbeats to be received
+		await delay(500) // to allow for timeout:
+		// console.log('----------- after timeout')
+		expect(mosDevice.getConnectionStatus()).toMatchObject({
+			PrimaryConnected: false,
+			PrimaryStatus: '', // if not connected this will contain human-readable error-message
+			SecondaryConnected: true
+			// SecondaryStatus: string // if not connected this will contain human-readable error-message
+		})
+
+		// @todo: add timeout test
+		// mock cause timeout
+		// expect(connectionStatusChanged).toHaveBeenCalledTimes(1)
+		// expect(connectionStatusChanged.mock.calls[0][0]).toMatchObject({PrimaryConnected: false})
+		await mosDevice.getAllMOSObjects().catch(() => null)
+		expect(false).toBe(true)
 
 		// Test proper dispose:
 		await mosDevice.dispose()

--- a/src/__tests__/MosDevice.spec.ts
+++ b/src/__tests__/MosDevice.spec.ts
@@ -106,7 +106,7 @@ describe('MosDevice: Profile 0', () => {
 
 		// jest.runOnlyPendingTimers() // allow for heartbeats to be sent
 		// jest.runOnlyPendingTimers() // allow for heartbeats to be received
-		await delay(300) // to allow for timeout:
+		await delay(500) // to allow for timeout:
 		// console.log('----------- after timeout')
 		expect(mosDevice.getConnectionStatus()).toMatchObject({
 			PrimaryConnected: false,

--- a/src/config/connectionConfig.ts
+++ b/src/config/connectionConfig.ts
@@ -7,6 +7,7 @@ export interface IConnectionConfig {
 	profiles: IProfiles
 	debug?: boolean
 	openRelay?: boolean
+	offspecFailover?: boolean
 }
 
 /** */
@@ -28,6 +29,7 @@ export class ConnectionConfig implements IConnectionConfig {
 	accepsConnectionsFrom: string[]
 	debug?: boolean
 	openRelay?: boolean
+	offspecFailover?: boolean
 
 	private _profiles: IProfiles = {
 		'0': false,

--- a/src/connection/mosSocketClient.ts
+++ b/src/connection/mosSocketClient.ts
@@ -262,7 +262,7 @@ export class MosSocketClient extends EventEmitter {
 	private _autoReconnectionAttempt (): void {
 		if (this._autoReconnect) {
 			if (this._reconnectAttempts > -1) {								// no reconnection if no valid reconnectionAttemps is set
-				if (this._reconnectAttempt > 0 && (this._reconnectAttempt >= this._reconnectAttempts)) {	// if current attempt is not less than max attempts
+				if (this._reconnectAttempts > 0 && (this._reconnectAttempt >= this._reconnectAttempts)) {	// if current attempt is not less than max attempts
 					// reset reconnection behaviour
 					this._clearConnectionAttemptTimer()
 					return
@@ -294,8 +294,8 @@ export class MosSocketClient extends EventEmitter {
   /** */
 	private _onConnected () {
 		this._client.emit(SocketConnectionEvent.ALIVE)
-		global.clearInterval(this._connectionAttemptTimer)
-		// this._clearConnectionAttemptTimer()
+		// global.clearInterval(this._connectionAttemptTimer)
+		this._clearConnectionAttemptTimer()
 		this.connected = true
 	}
 

--- a/src/connection/mosSocketClient.ts
+++ b/src/connection/mosSocketClient.ts
@@ -353,8 +353,12 @@ export class MosSocketClient extends EventEmitter {
 				} else {
 					// error message?
 					if (parsedData.mos.mosAck && parsedData.mos.mosAck.status === 'NACK') {
-						if (this._debug) console.log('Mos Error message:' + parsedData.mos.mosAck.statusDescription)
-						this.emit('error', 'Error message: ' + parsedData.mos.mosAck.statusDescription)
+						if (this._sentMessage && parsedData.mos.mosAck.statusDescription === 'Buddy server cannot respond because main server is available') {
+							this._sendReply(this._sentMessage.msg.messageID, 'Main server available', parsedData)
+						} else {
+							if (this._debug) console.log('Mos Error message:' + parsedData.mos.mosAck.statusDescription)
+							this.emit('error', 'Error message: ' + parsedData.mos.mosAck.statusDescription)
+						}
 					} else {
 						// unknown message..
 						this.emit('error', 'Unknown message: ' + messageString)

--- a/src/connection/mosSocketClient.ts
+++ b/src/connection/mosSocketClient.ts
@@ -261,8 +261,8 @@ export class MosSocketClient extends EventEmitter {
   /** */
 	private _autoReconnectionAttempt (): void {
 		if (this._autoReconnect) {
-			if (this._reconnectAttempts > 0) {								// no reconnection if no valid reconnectionAttemps is set
-				if ((this._reconnectAttempt >= this._reconnectAttempts)) {	// if current attempt is not less than max attempts
+			if (this._reconnectAttempts > -1) {								// no reconnection if no valid reconnectionAttemps is set
+				if (this._reconnectAttempt > 0 && (this._reconnectAttempt >= this._reconnectAttempts)) {	// if current attempt is not less than max attempts
 					// reset reconnection behaviour
 					this._clearConnectionAttemptTimer()
 					return


### PR DESCRIPTION
_Note: This is not ready to merge yet!_

This PR introduces a new feature, and related fixes, called "Buddy Server" which allows the MOS connection to keep functioning when one server goes down.

When the primary server disconnects (either through closing the socket or not responding in due time) this will switch the connection to the secondary server and resend the message(s). As per the MOS Spec the connection is switched back to Primary when the connection with the Buddy Server is lost or a NACK is sent by the Secondary server.

_Note: optionally an off spec behaviour is defined where the connection is switched back to Primary whenever the connection with the Primary server is reestablished._