### PR TITLE
Parser fix for techDescription error

### DIFF
--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -18,6 +18,7 @@ import { MosString128 } from '../dataTypes/mosString128'
 import { MosTime } from '../dataTypes/mosTime'
 import { MosDuration } from '../dataTypes/mosDuration'
 import { ROAck } from '../mosModel/ROAck'
+import { isObject } from 'util'
 
 function isEmpty (obj: any) {
 	if (typeof obj === 'object') {
@@ -197,10 +198,12 @@ export namespace Parser {
 			} else if (xmlPath.key === 'objMetadataPath') {
 				type = IMOSObjectPathType.METADATA_PATH
 			}
-			if (type && Object.keys(xmlPath.o).length > 0) {
+
+			const isObj = isObject(xmlPath.o)
+			if (type && isObj && Object.keys(xmlPath.o).length > 0) {
 				paths.push({
 					Type: type,
-					Description: xmlPath.o.techDescription || xmlPath.o.attributes.techDescription,
+					Description: xmlPath.o.techDescription || (xmlPath.o.attributes ? xmlPath.o.attributes.techDescription : undefined),
 					Target: xmlPath.o.text || xmlPath.o.$t
 				})
 			}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Error getting techDescription from undefined.

* **What is the new behavior (if this is a feature change)?**

No exception will be raised.

* **Other information**:

Just a small fix. When 'o' is a string, Object.keys(xmlPath.o).length is counting the string length, and then o.attributes.techDescription raises a error because o.attributes does not exists.