### PR TITLE
Feature:dont use query port

### DIFF
--- a/src/MosConnection.ts
+++ b/src/MosConnection.ts
@@ -100,7 +100,7 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 
 			primary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_LOWER, 'lower', true)
 			primary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_UPPER, 'upper', true)
-			primary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_QUERY, 'query', false)
+			if (!connectionOptions.primary.dontUseQueryPort) primary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_QUERY, 'query', false)
 
 			if (connectionOptions.secondary) {
 				secondary = new NCSServerConnection(
@@ -122,7 +122,7 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 				})
 				secondary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_LOWER, 'lower', true)
 				secondary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_UPPER, 'upper', true)
-				secondary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_QUERY, 'query', false)
+				if (!connectionOptions.primary.dontUseQueryPort) secondary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_QUERY, 'query', false)
 			}
 
 			// Initialize mosDevice:

--- a/src/api.ts
+++ b/src/api.ts
@@ -267,9 +267,13 @@ export interface IMOSDeviceConnectionOptions {
 			upper: number
 			lower: number
 			query: number
-		},
+		}
 		/** (Optional) Timeout for commands (ms) */
 		timeout?: number
+		/** (Optional) Some server doesn't expose the Query port, which can cause connection-errors.
+		 * Set this to true to not use that port (will cause some methods to stop working)
+		 */
+		dontUseQueryPort?: boolean
 	}
 	/** Connection options for the Secondary (Buddy) NCS-server */
 	secondary?: {
@@ -282,9 +286,14 @@ export interface IMOSDeviceConnectionOptions {
 			upper: number
 			lower: number
 			query: number
-		},
+		}
 		/** (Optional) Timeout for commands (ms) */
 		timeout?: number
+
+		/** (Optional) Some server doesn't expose the Query port, which can cause connection-errors.
+		 * Set this to true to not use that port (will cause some methods to stop working)
+		 */
+		dontUseQueryPort?: boolean
 	}
 }
 

--- a/src/connection/NCSServerConnection.ts
+++ b/src/connection/NCSServerConnection.ts
@@ -152,40 +152,29 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 		return connected
 	}
 
-	/** */
-	get lowerPortClients (): MosSocketClient[] {
+	private _getClients (clientDescription: string): MosSocketClient[] {
 		let clients: MosSocketClient[] = []
 		for (let i in this._clients) {
-			if (this._clients[i].clientDescription === 'lower') {
+			if (this._clients[i].clientDescription === clientDescription) {
 				clients.push(this._clients[i].client)
 			}
 		}
 
 		return clients
+	}
+	/** */
+	get lowerPortClients (): MosSocketClient[] {
+		return this._getClients('lower')
 	}
 
 	/** */
 	get upperPortClients (): MosSocketClient[] {
-		let clients: MosSocketClient[] = []
-		for (let i in this._clients) {
-			if (this._clients[i].clientDescription === 'upper') {
-				clients.push(this._clients[i].client)
-			}
-		}
-
-		return clients
+		return this._getClients('upper')
 	}
 
 	/** */
 	get queryPortClients (): MosSocketClient[] {
-		let clients: MosSocketClient[] = []
-		for (let i in this._clients) {
-			if (this._clients[i].clientDescription === 'query') {
-				clients.push(this._clients[i].client)
-			}
-		}
-
-		return clients
+		return this._getClients('query')
 	}
 	get host (): string {
 		return this._host

--- a/src/connection/NCSServerConnection.ts
+++ b/src/connection/NCSServerConnection.ts
@@ -109,7 +109,7 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 		} else if (message.port === 'query') {
 			clients = this.queryPortClients
 		} else {
-			throw Error('Unknown port name: "' + message.port + '"')
+			throw Error(`No "${message.port}" ports found`)
 		}
 		return new Promise((resolve, reject) => {
 			if (clients && clients.length) {

--- a/src/connection/Server.ts
+++ b/src/connection/Server.ts
@@ -21,39 +21,28 @@ export class Server {
 		delete this._sockets[socketID + '']
 	}
 
-	/** */
-	get lowerPortSockets (): Socket[] {
+	private _getSockets (portDescription: string): Socket[] {
 		let sockets: Socket[] = []
 		for (let i in this._sockets) {
-			if (this._sockets[i].portDescription === 'lower') {
+			if (this._sockets[i].portDescription === portDescription) {
 				sockets.push(this._sockets[i].socket)
 			}
 		}
 
 		return sockets
+	}
+	/** */
+	get lowerPortSockets (): Socket[] {
+		return this._getSockets('lower')
 	}
 
 	/** */
 	get upperPortSockets (): Socket[] {
-		let sockets: Socket[] = []
-		for (let i in this._sockets) {
-			if (this._sockets[i].portDescription === 'upper') {
-				sockets.push(this._sockets[i].socket)
-			}
-		}
-
-		return sockets
+		return this._getSockets('upper')
 	}
 
 	/** */
 	get queryPortSockets (): Socket[] {
-		let sockets: Socket[] = []
-		for (let i in this._sockets) {
-			if (this._sockets[i].portDescription === 'query') {
-				sockets.push(this._sockets[i].socket)
-			}
-		}
-
-		return sockets
+		return this._getSockets('query')
 	}
 }


### PR DESCRIPTION
This PR adds an optional option to `connectionOptions.dontUseQueryPort` which causes the library to not try to connect to the "query port".

The motivation for this is that I've noticed that some servers doesn't expose that port, which causes that connection to fail repeatedly, flooding the logs with errors, even though the other functions still work fine.