### PR TITLE
fix: resolve an issue with a duplicated type MosDuration

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import { IProfiles } from './config/connectionConfig'
 import { MosTime } from './dataTypes/mosTime'
-import { MosDuration } from './dataTypes/mosDuration'
+import { MosDuration as MosDurationDataType } from './dataTypes/mosDuration'
 import { MosString128 } from './dataTypes/mosString128'
 import { IMOSExternalMetaData } from './dataTypes/mosExternalMetaData'
 import { IMOSListMachInfo, MOSAck, MosItemReplaceOptions } from './mosModel'
@@ -214,7 +214,7 @@ export interface IMOSItem {
 	MosObjects?: Array<IMOSObject>
 }
 
-export type MosDuration = MosDuration // HH:MM:SS
+export type MosDuration = MosDurationDataType // HH:MM:SS
 
 export interface IMOSAck {
 	ID: MosString128


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Imports MosDuration from `dataTypes/mosDuration.ts` as MosDurationDataType in `api.ts`

* **What is the current behavior?** (You can also link to an open issue here)

MosDuration is imported and then redefined as type MosDuration = MosDuration. 

* **What is the new behavior (if this is a feature change)?**

Redefinition of MosDuration within `api.ts` is avoided.

* **Other information**:
