### PR TITLE
fix: editorial start and duration can be 0

### DIFF
--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -273,14 +273,16 @@ export namespace Parser {
 		// 	  objProxyPath*
 		// 	  objMetadataPath*
 
-		if (item.Channel) 				addTextElement(xmlItem, 'itemChannel', {}, item.Channel)
-		if (item.EditorialStart) 		addTextElement(xmlItem, 'itemEdStart', {}, item.EditorialStart)
-		if (item.EditorialDuration) 	addTextElement(xmlItem, 'itemEdDur', {}, item.EditorialDuration)
-		if (item.UserTimingDuration) 	addTextElement(xmlItem, 'itemUserTimingDur', {}, item.UserTimingDuration)
-		if (item.Trigger) 				addTextElement(xmlItem, 'itemTrigger', {}, item.Trigger)
-		if (item.MacroIn) 				addTextElement(xmlItem, 'macroIn', {}, item.MacroIn)
-		if (item.MacroOut) 				addTextElement(xmlItem, 'macroOut', {}, item.MacroOut)
-		if (item.MacroOut)				addTextElement(xmlItem, 'mosExternalMetadata', {}, item.MacroOut)
+		if (item.Channel) 							addTextElement(xmlItem, 'itemChannel', {}, item.Channel)
+		if (item.EditorialStart !== undefined) 		addTextElement(xmlItem, 'itemEdStart', {}, item.EditorialStart)
+		if (item.EditorialDuration !== undefined) 	addTextElement(xmlItem, 'itemEdDur', {}, item.EditorialDuration)
+		if (item.UserTimingDuration !== undefined) {
+			addTextElement(xmlItem, 'itemUserTimingDur', {}, item.UserTimingDuration)
+		}
+		if (item.Trigger) 	addTextElement(xmlItem, 'itemTrigger', {}, item.Trigger)
+		if (item.MacroIn) 	addTextElement(xmlItem, 'macroIn', {}, item.MacroIn)
+		if (item.MacroOut) 	addTextElement(xmlItem, 'macroOut', {}, item.MacroOut)
+		if (item.MacroOut)	addTextElement(xmlItem, 'mosExternalMetadata', {}, item.MacroOut)
 		if (item.MosExternalMetaData) {
 			item.MosExternalMetaData.forEach((md) => {
 				let xmlMetaData = metaData2xml(md)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

When calling a roStoryReplace the editorial start and duration values can be 0


* **What is the current behavior?** (You can also link to an open issue here)

When calling a roStoryReplace the editorial start and duration values will be ignored if set to 0.