### PR TITLE
Feat/on req all

### DIFF
--- a/src/MosDevice.ts
+++ b/src/MosDevice.ts
@@ -79,7 +79,7 @@ export class MosDevice implements IMOSDevice {
 	private _idSecondary: string | null
 	private _debug: boolean = false
 
-	private supportedProfiles: {[profile: string]: (boolean | string), deviceType: string} = {
+	private supportedProfiles: {[profile: string]: (boolean | string), deviceType: 'NCS' | 'MOS'} = {
 		deviceType: 'MOS',
 		profile0: false,
 		profile1: false,

--- a/src/MosDevice.ts
+++ b/src/MosDevice.ts
@@ -56,6 +56,7 @@ import {
 	MosReqObjList
 } from './mosModel'
 import { MosMessage } from './mosModel/MosMessage'
+import { ROListAll } from './mosModel/profile2/ROListAll'
 
 export class MosDevice implements IMOSDevice {
 
@@ -132,6 +133,7 @@ export class MosDevice implements IMOSDevice {
 	private _callbackOnMosReqSearchableSchema?: (username: string) => Promise<IMOSSearchableSchema>
 
 	// Profile 4
+	private _callbackOnROReqAll?: () => Promise<IMOSRunningOrder[]>
 	private _callbackOnROStory?: (story: IMOSROFullStory) => Promise<IMOSROAck>
 
 	constructor (
@@ -646,6 +648,13 @@ export class MosDevice implements IMOSDevice {
 				.catch(reject)
 
 			// Profile 4
+			} else if (data.roReqAll && typeof this._callbackOnROReqAll === 'function') {
+				this._callbackOnROReqAll().then((list: IMOSRunningOrder[]) => {
+					let roListAll = new ROListAll()
+					roListAll.ROs = list
+					resolve(roListAll)
+				}).catch(reject)
+
 			} else if (data.roStorySend && typeof this._callbackOnROStory === 'function') {
 				let story: IMOSROFullStory = Parser.xml2FullStory(data.roStorySend)
 				this._callbackOnROStory(story).then((resp: IMOSROAck) => {
@@ -988,6 +997,9 @@ export class MosDevice implements IMOSDevice {
 	}
 
 	/* Profile 4 */
+	onROReqAll (cb: () => Promise<IMOSRunningOrder[]>) {
+		this._callbackOnROReqAll = cb
+	}
 	getAllRunningOrders (): Promise<Array<IMOSRunningOrderBase>> {
 		let message = new ROReqAll()
 		return new Promise((resolve, reject) => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -125,6 +125,7 @@ export interface IMOSDevice {
 	mosRequestObjectList: (reqObjList: IMosRequestObjectList) => Promise<IMosObjectList>
 	onMosReqObjectAction: (cb: (action: string, obj: IMOSObject) => Promise<IMOSAck>) => void
 	/* Profile 4 */
+	onROReqAll: (cb: () => Promise<IMOSRunningOrder[]>) => void
 	getAllRunningOrders: () => Promise<Array<IMOSRunningOrderBase>> // send roReqAll
 	onROStory: (cb: (story: IMOSROFullStory) => Promise<IMOSROAck>) => void // roStorySend
 }

--- a/src/mosModel/Parser.ts
+++ b/src/mosModel/Parser.ts
@@ -117,10 +117,10 @@ export namespace Parser {
 	export function story2xml (story: IMOSROStory): XMLBuilder.XMLElement {
 		let xmlStory = XMLBuilder.create('story')
 
-		addTextElement(xmlStory, 'storyID', {}, story.ID)
+		addTextElement(xmlStory, 'storyID', story.ID)
 		// if (story.Slug) addTextElement(xmlStory, 'storySlug', {}, story.)
-		if (story.Slug) addTextElement(xmlStory, 'storySlug', {}, story.Slug)
-		if (story.Number) addTextElement(xmlStory, 'storyNum', {}, story.Number)
+		if (story.Slug) addTextElement(xmlStory, 'storySlug', story.Slug)
+		if (story.Number) addTextElement(xmlStory, 'storyNum', story.Number)
 
 		if (story.MosExternalMetaData) {
 			story.MosExternalMetaData.forEach((md: IMOSExternalMetaData) => {
@@ -241,28 +241,28 @@ export namespace Parser {
 		let xmlObjPaths = XMLBuilder.create('objPaths')
 		paths.forEach((path: IMOSObjectPath) => {
 			if (path.Type === IMOSObjectPathType.PATH) {
-				addTextElement(xmlObjPaths, 'objPath', {
+				addTextElement(xmlObjPaths, 'objPath', path.Target, {
 					techDescription: path.Description
-				}, path.Target)
+				})
 			} else if (path.Type === IMOSObjectPathType.PROXY_PATH) {
-				addTextElement(xmlObjPaths, 'objProxyPath', {
+				addTextElement(xmlObjPaths, 'objProxyPath', path.Target, {
 					techDescription: path.Description
-				}, path.Target)
+				})
 			} else if (path.Type === IMOSObjectPathType.METADATA_PATH) {
-				addTextElement(xmlObjPaths, 'objMetadataPath', {
+				addTextElement(xmlObjPaths, 'objMetadataPath', path.Target, {
 					techDescription: path.Description
-				}, path.Target)
+				})
 			}
 		})
 		return xmlObjPaths
 	}
 	export function item2xml (item: IMOSItem): XMLBuilder.XMLElement {
 		let xmlItem = XMLBuilder.create('item')
-		addTextElement(xmlItem, 'itemID', {}, item.ID)
-		if (item.Slug) 					addTextElement(xmlItem, 'itemSlug', {}, item.Slug)
-		addTextElement(xmlItem, 'objID', {}, item.ObjectID)
-		addTextElement(xmlItem, 'mosID', {}, item.MOSID)
-		if (item.mosAbstract) 			addTextElement(xmlItem, 'mosAbstract', {}, item.mosAbstract)
+		addTextElement(xmlItem, 'itemID', item.ID)
+		if (item.Slug) 					addTextElement(xmlItem, 'itemSlug', item.Slug)
+		addTextElement(xmlItem, 'objID', item.ObjectID)
+		addTextElement(xmlItem, 'mosID', item.MOSID)
+		if (item.mosAbstract) 			addTextElement(xmlItem, 'mosAbstract', item.mosAbstract)
 
 		if (item.Paths) {
 			let xmlObjPaths = objPaths2xml(item.Paths)
@@ -273,16 +273,16 @@ export namespace Parser {
 		// 	  objProxyPath*
 		// 	  objMetadataPath*
 
-		if (item.Channel) 							addTextElement(xmlItem, 'itemChannel', {}, item.Channel)
-		if (item.EditorialStart !== undefined) 		addTextElement(xmlItem, 'itemEdStart', {}, item.EditorialStart)
-		if (item.EditorialDuration !== undefined) 	addTextElement(xmlItem, 'itemEdDur', {}, item.EditorialDuration)
+		if (item.Channel) 							addTextElement(xmlItem, 'itemChannel', item.Channel)
+		if (item.EditorialStart !== undefined) 		addTextElement(xmlItem, 'itemEdStart', item.EditorialStart)
+		if (item.EditorialDuration !== undefined) 	addTextElement(xmlItem, 'itemEdDur', item.EditorialDuration)
 		if (item.UserTimingDuration !== undefined) {
-			addTextElement(xmlItem, 'itemUserTimingDur', {}, item.UserTimingDuration)
+			addTextElement(xmlItem, 'itemUserTimingDur', item.UserTimingDuration)
 		}
-		if (item.Trigger) 	addTextElement(xmlItem, 'itemTrigger', {}, item.Trigger)
-		if (item.MacroIn) 	addTextElement(xmlItem, 'macroIn', {}, item.MacroIn)
-		if (item.MacroOut) 	addTextElement(xmlItem, 'macroOut', {}, item.MacroOut)
-		if (item.MacroOut)	addTextElement(xmlItem, 'mosExternalMetadata', {}, item.MacroOut)
+		if (item.Trigger) 	addTextElement(xmlItem, 'itemTrigger', item.Trigger)
+		if (item.MacroIn) 	addTextElement(xmlItem, 'macroIn', item.MacroIn)
+		if (item.MacroOut) 	addTextElement(xmlItem, 'macroOut', item.MacroOut)
+		if (item.MacroOut)	addTextElement(xmlItem, 'mosExternalMetadata', item.MacroOut)
 		if (item.MosExternalMetaData) {
 			item.MosExternalMetaData.forEach((md) => {
 				let xmlMetaData = metaData2xml(md)
@@ -468,27 +468,27 @@ export namespace Parser {
 		return xml
 	}
 	export function attachMosObj2xml (obj: IMOSObject, xml: XMLBuilder.XMLElement): void {
-		if (obj.ID) addTextElement(xml, 'objID', {}, obj.ID)
-		addTextElement(xml, 'objSlug', {}, obj.Slug)
-		if (obj.MosAbstract) 	addTextElement(xml, 'mosAbstract', {}, obj.MosAbstract)
-		if (obj.Group) 			addTextElement(xml, 'objGroup', {}, obj.Group)
-		addTextElement(xml, 'objType', {}, obj.Type)
-		addTextElement(xml, 'objTB', {}, obj.TimeBase)
-		addTextElement(xml, 'objRev', {}, obj.Revision)
-		addTextElement(xml, 'objDur', {}, obj.Duration)
-		addTextElement(xml, 'status', {}, obj.Status)
-		addTextElement(xml, 'objAir', {}, obj.AirStatus)
+		if (obj.ID) addTextElement(xml, 'objID', obj.ID)
+		addTextElement(xml, 'objSlug', obj.Slug)
+		if (obj.MosAbstract) 	addTextElement(xml, 'mosAbstract', obj.MosAbstract)
+		if (obj.Group) 			addTextElement(xml, 'objGroup', obj.Group)
+		addTextElement(xml, 'objType', obj.Type)
+		addTextElement(xml, 'objTB', obj.TimeBase)
+		addTextElement(xml, 'objRev', obj.Revision)
+		addTextElement(xml, 'objDur', obj.Duration)
+		addTextElement(xml, 'status', obj.Status)
+		addTextElement(xml, 'objAir', obj.AirStatus)
 
 		if (obj.Paths) {
 			let xmlObjPaths = objPaths2xml(obj.Paths)
 			xml.importDocument(xmlObjPaths)
 		}
 
-		addTextElement(xml, 'createdBy', {}, obj.CreatedBy)
-		addTextElement(xml, 'created', {}, obj.Created)
-		if (obj.ChangedBy) addTextElement(xml, 'changedBy', {}, 	obj.ChangedBy)
-		if (obj.Changed) addTextElement(xml, 'changed', {}, 		obj.Changed)
-		if (obj.Description) addTextElement(xml, 'description', {}, 	obj.Description)
+		addTextElement(xml, 'createdBy', obj.CreatedBy)
+		addTextElement(xml, 'created', obj.Created)
+		if (obj.ChangedBy) addTextElement(xml, 'changedBy', obj.ChangedBy)
+		if (obj.Changed) addTextElement(xml, 'changed', obj.Changed)
+		if (obj.Description) addTextElement(xml, 'description', obj.Description)
 		if (obj.MosExternalMetaData) {
 			obj.MosExternalMetaData.forEach((md) => {
 				let xmlMetaData = metaData2xml(md)

--- a/src/mosModel/profile0/heartBeat.ts
+++ b/src/mosModel/profile0/heartBeat.ts
@@ -15,7 +15,8 @@ export class HeartBeat extends MosMessage {
 
   /** */
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
-		let messageBlock = addTextElement(XMLBuilder.create('heartbeat'), 'time', {}, this.time)
-		return messageBlock
+		const heartbeat = XMLBuilder.create('heartbeat')
+		addTextElement(heartbeat, 'time', this.time)
+		return heartbeat
 	}
 }

--- a/src/mosModel/profile0/listMachInfo.ts
+++ b/src/mosModel/profile0/listMachInfo.ts
@@ -61,22 +61,28 @@ export class ListMachineInfo extends MosMessage {
   /** */
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
 
-		let root = XMLBuilder.create('listMachInfo')
-		addTextElement(root, 'manufacturer', this.info.manufacturer)
-		addTextElement(root, 'model', this.info.model)
-		addTextElement(root, 'hwRev', this.info.hwRev)
-		addTextElement(root, 'swRev', this.info.swRev)
-		addTextElement(root, 'DOM', this.info.DOM)
-		addTextElement(root, 'SN', this.info.SN)
-		addTextElement(root, 'ID', this.info.ID)
-		addTextElement(root, 'time', this.info.time)
-		if (this.info.opTime) addTextElement(root, 'opTime', this.info.opTime)
-		addTextElement(root, 'mosRev', this.info.mosRev)
+		let xmlListMachInfo = XMLBuilder.create('listMachInfo')
+		addTextElement(xmlListMachInfo, 'manufacturer', this.info.manufacturer)
+		console.log('this.info.manufacturer', this.info.manufacturer, this.info.manufacturer.toString())
+		addTextElement(xmlListMachInfo, 'model', this.info.model)
+		addTextElement(xmlListMachInfo, 'hwRev', this.info.hwRev)
+		addTextElement(xmlListMachInfo, 'swRev', this.info.swRev)
+		addTextElement(xmlListMachInfo, 'DOM', this.info.DOM)
+		addTextElement(xmlListMachInfo, 'SN', this.info.SN)
+		addTextElement(xmlListMachInfo, 'ID', this.info.ID)
+		addTextElement(xmlListMachInfo, 'time', this.info.time)
+		if (this.info.opTime) addTextElement(xmlListMachInfo, 'opTime', this.info.opTime)
+		addTextElement(xmlListMachInfo, 'mosRev', this.info.mosRev)
 
-		let p = addTextElement(root, 'supportedProfiles').att('deviceType', this.info.supportedProfiles.deviceType)
+		// let p = addTextElement(root, 'supportedProfiles').att('deviceType', this.info.supportedProfiles.deviceType)
+		const xmlSupportedProfiles = XMLBuilder.create('supportedProfiles')
+		xmlSupportedProfiles.att('deviceType', this.info.supportedProfiles.deviceType)
+		// let p = addTextElement(root, 'supportedProfiles').att('deviceType', this.info.supportedProfiles.deviceType)
 		for (let i = 0; i < 8; i++) {
-			addTextElement(p, 'mosProfile', ((this as any).info.supportedProfiles['profile' + i] ? 'YES' : 'NO')).att('number', i)
+			addTextElement(xmlSupportedProfiles, 'mosProfile', ((this as any).info.supportedProfiles['profile' + i] ? 'YES' : 'NO')).att('number', i)
 		}
-		return root
+		xmlListMachInfo.importDocument(xmlSupportedProfiles)
+		console.log('xml', xmlListMachInfo.end({ pretty: true }))
+		return xmlListMachInfo
 	}
 }

--- a/src/mosModel/profile0/listMachInfo.ts
+++ b/src/mosModel/profile0/listMachInfo.ts
@@ -33,7 +33,7 @@ export interface IMOSListMachInfo {
 	mosRev: MosString128     // MOS Revision: Text description. 128 chars max.
 
 	supportedProfiles: {
-		deviceType: string,                 // deviceType="NCS"
+		deviceType: 'NCS' | 'MOS',
 		profile0?: boolean,
 		profile1?: boolean,
 		profile2?: boolean,

--- a/src/mosModel/profile1/mosAck.ts
+++ b/src/mosModel/profile1/mosAck.ts
@@ -23,10 +23,10 @@ export class MOSAck extends MosMessage implements IMOSAck {
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
 		let root = XMLBuilder.create('mosAck')
 
-		addTextElement(root, 'objID', {}, this.ID)
-		addTextElement(root, 'objRev', {}, this.Revision)
-		addTextElement(root, 'status', {}, (IMOSAckStatus as any)[this.Status])
-		addTextElement(root, 'statusDescription', {}, this.Description)
+		addTextElement(root, 'objID', this.ID)
+		addTextElement(root, 'objRev', this.Revision)
+		addTextElement(root, 'status', (IMOSAckStatus as any)[this.Status])
+		addTextElement(root, 'statusDescription', this.Description)
 
 		return root
 	}

--- a/src/mosModel/profile1/reqMosObj.ts
+++ b/src/mosModel/profile1/reqMosObj.ts
@@ -16,7 +16,7 @@ export class ReqMosObj extends MosMessage {
   /** */
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
 		let root = XMLBuilder.create('mosReqObj')
-		addTextElement(root, 'objID', {}, this.objId)
+		addTextElement(root, 'objID', this.objId)
 		return root
 	}
 }

--- a/src/mosModel/profile1/reqMosObjAll.ts
+++ b/src/mosModel/profile1/reqMosObjAll.ts
@@ -15,7 +15,7 @@ export class ReqMosObjAll extends MosMessage {
   /** */
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
 		let root = XMLBuilder.create('mosReqAll')
-		addTextElement(root, 'pause', {}, this.pause + '')
+		addTextElement(root, 'pause', this.pause + '')
 		return root
 	}
 }

--- a/src/mosModel/profile2/ROAck.ts
+++ b/src/mosModel/profile2/ROAck.ts
@@ -24,8 +24,8 @@ export class ROAck extends MosMessage implements IMOSROAck {
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
 		let root = XMLBuilder.create('roAck')
 
-		addTextElement(root, 'roID', {}, this.ID)
-		addTextElement(root, 'roStatus', {}, this.Status)
+		addTextElement(root, 'roID', this.ID)
+		addTextElement(root, 'roStatus', this.Status)
 
 		// TODO: Loop over Stories, Items and Object
 

--- a/src/mosModel/profile2/ROList.ts
+++ b/src/mosModel/profile2/ROList.ts
@@ -21,8 +21,8 @@ export class ROList extends MosMessage {
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
 		let root = XMLBuilder.create('roList')
 
-		addTextElement(root, 'roID', {}, this.RO.ID)
-		addTextElement(root, 'roSlug', {}, this.RO.Slug)
+		addTextElement(root, 'roID', this.RO.ID)
+		addTextElement(root, 'roSlug', this.RO.Slug)
 
 		this.RO.Stories.forEach((story: IMOSROStory) => {
 			let xmlStory = Parser.story2xml(story)

--- a/src/mosModel/profile2/ROListAll.ts
+++ b/src/mosModel/profile2/ROListAll.ts
@@ -1,0 +1,32 @@
+import * as XMLBuilder from 'xmlbuilder'
+import { MosMessage } from '../MosMessage'
+import {
+	IMOSRunningOrder
+} from '../../api'
+import { addTextElement } from '../../utils/Utils'
+
+export class ROListAll extends MosMessage {
+
+	ROs: IMOSRunningOrder[]
+
+  /** */
+	constructor () {
+		super()
+	}
+
+  /** */
+	get messageXMLBlocks (): XMLBuilder.XMLElement {
+		let root = XMLBuilder.create('roListAll')
+
+		this.ROs.forEach((RO: IMOSRunningOrder) => {
+			let xmlRO = XMLBuilder.create('ro')
+
+			addTextElement(root, 'roID', RO.ID)
+			addTextElement(root, 'roSlug', RO.Slug)
+
+			root.importDocument(xmlRO)
+		})
+
+		return root
+	}
+}

--- a/src/mosModel/profile2/roElementStat.ts
+++ b/src/mosModel/profile2/roElementStat.ts
@@ -35,13 +35,13 @@ export class ROElementStat extends MosMessage {
 		let root = XMLBuilder.create('roElementStat')
 		root.attribute('element', this.options.type.toString())
 
-		addTextElement(root, 'roID', {}, this.options.roId)
-		if (this.options.storyId) 		addTextElement(root, 'storyID', {}, this.options.storyId)
-		if (this.options.itemId) 		addTextElement(root, 'itemID', {}, this.options.itemId)
-		if (this.options.objId) 		addTextElement(root, 'objID', {}, this.options.objId)
-		if (this.options.itemChannel) 	addTextElement(root, 'itemChannel', {}, this.options.itemChannel)
-		addTextElement(root, 'status', {}, this.options.status)
-		addTextElement(root, 'time', {}, this.time)
+		addTextElement(root, 'roID', this.options.roId)
+		if (this.options.storyId) 		addTextElement(root, 'storyID', this.options.storyId)
+		if (this.options.itemId) 		addTextElement(root, 'itemID', this.options.itemId)
+		if (this.options.objId) 		addTextElement(root, 'objID', this.options.objId)
+		if (this.options.itemChannel) 	addTextElement(root, 'itemChannel', this.options.itemChannel)
+		addTextElement(root, 'status', this.options.status)
+		addTextElement(root, 'time', this.time)
 		return root
 	}
 }

--- a/src/mosModel/profile2/roReq.ts
+++ b/src/mosModel/profile2/roReq.ts
@@ -16,7 +16,7 @@ export class ROReq extends MosMessage {
   /** */
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
 		let root = XMLBuilder.create('roReq')
-		addTextElement(root, 'roID', {}, this.roId)
+		addTextElement(root, 'roID', this.roId)
 		return root
 	}
 }

--- a/src/mosModel/profile3/mosItemReplace.ts
+++ b/src/mosModel/profile3/mosItemReplace.ts
@@ -24,8 +24,8 @@ export class MosItemReplace extends MosMessage {
 		const item = this.options.item
 		const root = XMLBuilder.create('mosItemReplace')
 
-		addTextElement(root, 'roID', {}, this.options.roID)
-		addTextElement(root, 'storyID', {}, this.options.storyID)
+		addTextElement(root, 'roID', this.options.roID)
+		addTextElement(root, 'storyID', this.options.storyID)
 		root.importDocument(Parser.item2xml(item))
 
 		return root

--- a/src/mosModel/profile3/mosListSearchableSchema.ts
+++ b/src/mosModel/profile3/mosListSearchableSchema.ts
@@ -16,7 +16,7 @@ export class MosListSearchableSchema extends MosMessage {
 		const xml = XMLBuilder.create('mosListSearchableSchema')
 		xml.att('username', this.options.username)
 
-		addTextElement(xml, 'mosSchema', {}, this.options.mosSchema)
+		addTextElement(xml, 'mosSchema', this.options.mosSchema)
 
 		return xml
 	}

--- a/src/mosModel/profile3/mosObjList.ts
+++ b/src/mosModel/profile3/mosObjList.ts
@@ -14,22 +14,23 @@ export class MosObjList extends MosMessage {
 	}
 
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
-		const xml = XMLBuilder.create('mosObjList')
-		xml.att('username', this.options.username)
+		const xmlMosObjList = XMLBuilder.create('mosObjList')
+		xmlMosObjList.att('username', this.options.username)
 
-		addTextElement(xml, 'queryID', {}, this.options.queryID)
-		addTextElement(xml, 'listReturnStart', {}, this.options.listReturnStart)
-		addTextElement(xml, 'listReturnEnd', {}, this.options.listReturnEnd)
-		addTextElement(xml, 'listReturnTotal', {}, this.options.listReturnTotal)
-		if (this.options.listReturnStatus) addTextElement(xml, 'listReturnStatus', {}, this.options.listReturnStatus)
+		addTextElement(xmlMosObjList, 'queryID', this.options.queryID)
+		addTextElement(xmlMosObjList, 'listReturnStart', this.options.listReturnStart)
+		addTextElement(xmlMosObjList, 'listReturnEnd', this.options.listReturnEnd)
+		addTextElement(xmlMosObjList, 'listReturnTotal', this.options.listReturnTotal)
+		if (this.options.listReturnStatus) addTextElement(xmlMosObjList, 'listReturnStatus', this.options.listReturnStatus)
 
 		if (this.options.list) {
-			const listEl = addTextElement(xml, 'list')
+			const xmlList = XMLBuilder.create('list')
 			for (const object of this.options.list) {
-				listEl.importDocument(Parser.mosObj2xml(object))
+				xmlList.importDocument(Parser.mosObj2xml(object))
 			}
+			xmlMosObjList.importDocument(xmlList)
 		}
 
-		return xml
+		return xmlMosObjList
 	}
 }

--- a/src/mosModel/profile3/mosReqObjList.ts
+++ b/src/mosModel/profile3/mosReqObjList.ts
@@ -13,23 +13,30 @@ export class MosReqObjList extends MosMessage {
 	}
 
 	get messageXMLBlocks (): XMLBuilder.XMLElement {
-		const xml = XMLBuilder.create('mosReqObjList')
-		xml.att('username', this.options.username)
+		const xmlMosReqObjList = XMLBuilder.create('mosReqObjList')
+		xmlMosReqObjList.att('username', this.options.username)
 
-		addTextElement(xml, 'username', {}, this.options.username)
-		addTextElement(xml, 'queryID', {}, this.options.queryID)
-		addTextElement(xml, 'listReturnStart', {}, this.options.listReturnStart)
-		addTextElement(xml, 'listReturnEnd', {}, this.options.listReturnEnd)
-		addTextElement(xml, 'generalSearch', {}, this.options.generalSearch)
-		addTextElement(xml, 'mosSchema', {}, this.options.mosSchema)
+		addTextElement(xmlMosReqObjList, 'username', this.options.username)
+		addTextElement(xmlMosReqObjList, 'queryID', this.options.queryID)
+		addTextElement(xmlMosReqObjList, 'listReturnStart', this.options.listReturnStart)
+		addTextElement(xmlMosReqObjList, 'listReturnEnd', this.options.listReturnEnd)
+		addTextElement(xmlMosReqObjList, 'generalSearch', this.options.generalSearch)
+		addTextElement(xmlMosReqObjList, 'mosSchema', this.options.mosSchema)
 
 		for (const searchGroup of this.options.searchGroups) {
-			const groupEle = addTextElement(xml, 'searchGroup')
+			const xmlSearchGroup = XMLBuilder.create('searchGroup')
 			for (const searchField of searchGroup.searchFields) {
-				addTextElement(groupEle, 'searchField', searchField)
+
+				const attributes: {[key: string]: string} = {}
+				Object.keys(searchField).forEach(key => {
+					// @ts-ignore
+					attributes[key] = searchField[key] + ''
+				})
+				addTextElement(xmlSearchGroup, 'searchField', '', attributes)
 			}
+			xmlMosReqObjList.importDocument(xmlSearchGroup)
 		}
 
-		return xml
+		return xmlMosReqObjList
 	}
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -156,16 +156,20 @@ export function xml2js (messageString: string): object {
 export function addTextElement (
 	root: XMLBuilder.XMLElement,
 	elementName: string,
-	attributes?: Object, text?: string | number | null | MosString128 | MosTime
+	text?: string | number | null | MosString128 | MosTime,
+	attributes?: { [key: string]: string}
 ): XMLBuilder.XMLElement {
-	root.element(
-		elementName,
-		attributes,
+	const txt = (
 		text === null ?
 			null :
 		text !== undefined ?
 			text.toString() :
 		undefined
 	)
-	return root
+	const element = root.element(
+		elementName,
+		attributes || {},
+		txt
+	)
+	return element
 }


### PR DESCRIPTION
This PR fixes some issues I found:
* roReqAll command was missing on the server (receiving) side
* listMachInfo.supportedProfiles.deviceTypes is defined in the protocol as "MOS" or "NCS"
* a bug in listMachInfo, ultimately caused by easy-to-misunderstand code and too-loose typings in
`addTextElement`

