### PR TITLE
Reduce the amount of logging information in production

### DIFF
--- a/src/MosConnection.ts
+++ b/src/MosConnection.ts
@@ -97,6 +97,9 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 			primary.on('error', (str: string) => {
 				this.emit('error', 'primary: ' + str)
 			})
+			primary.on('info', (str: string) => {
+				this.emit('info', 'primary: ' + str)
+			})
 
 			primary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_LOWER, 'lower', true)
 			primary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_UPPER, 'upper', true)
@@ -119,6 +122,9 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 				})
 				secondary.on('error', (str: string) => {
 					this.emit('error', 'secondary: ' + str)
+				})
+				secondary.on('info', (str: string) => {
+					this.emit('info', 'secondary: ' + str)
 				})
 				secondary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_LOWER, 'lower', true)
 				secondary.createClient(MosConnection.nextSocketID, MosConnection.CONNECTION_PORT_UPPER, 'upper', true)
@@ -464,6 +470,7 @@ export class MosConnection extends EventEmitter implements IMosConnection {
 			}
 		})
 		client.socket.on('error', (e: Error) => {
+			this.emit('error', `Socket had error (${socketID}, ${client.socket.remoteAddress}, ${client.portDescription}): ${e}`)
 			if (this._debug) console.log(`Socket had error (${socketID}, ${client.socket.remoteAddress}, ${client.portDescription}): ${e}`)
 		})
 

--- a/src/__tests__/MosDevice.spec.ts
+++ b/src/__tests__/MosDevice.spec.ts
@@ -201,7 +201,7 @@ describe('MosDevice: Profile 0', () => {
 		})
 
 		expect(errorReported).toHaveBeenCalledTimes(1)
-		
+
 		// Test proper dispose:
 		await mosDevice.dispose()
 

--- a/src/__tests__/MosDevice.spec.ts
+++ b/src/__tests__/MosDevice.spec.ts
@@ -92,6 +92,8 @@ describe('MosDevice: Profile 0', () => {
 		expect(connMocks[2].connect.mock.calls[0][1]).toEqual('127.0.0.1')
 
 		let connectionStatusChanged = jest.fn()
+		let errorReported = jest.fn()
+		mos.on('error', errorReported)
 
 		mosDevice.onConnectionChange((connectionStatus: IMOSConnectionStatus) => {
 			connectionStatusChanged(connectionStatus)
@@ -127,6 +129,8 @@ describe('MosDevice: Profile 0', () => {
 			// SecondaryStatus: string // if not connected this will contain human-readable error-message
 		})
 
+		expect(errorReported).toHaveBeenCalledTimes(2)
+
 		// @todo: add timeout test
 		// mock cause timeout
 		// expect(connectionStatusChanged).toHaveBeenCalledTimes(1)
@@ -159,6 +163,8 @@ describe('MosDevice: Profile 0', () => {
 		expect(connMocks[2].connect.mock.calls[0][1]).toEqual('127.0.0.1')
 
 		let connectionStatusChanged = jest.fn()
+		let errorReported = jest.fn()
+		mos.on('error', errorReported)
 
 		mosDevice.onConnectionChange((connectionStatus: IMOSConnectionStatus) => {
 			connectionStatusChanged(connectionStatus)
@@ -194,6 +200,8 @@ describe('MosDevice: Profile 0', () => {
 			SecondaryStatus: '' // if not connected this will contain human-readable error-message
 		})
 
+		expect(errorReported).toHaveBeenCalledTimes(1)
+		
 		// Test proper dispose:
 		await mosDevice.dispose()
 

--- a/src/connection/NCSServerConnection.ts
+++ b/src/connection/NCSServerConnection.ts
@@ -81,6 +81,7 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 	connect () {
 		for (let i in this._clients) {
 			// Connect client
+			this.emit('info', `Connect client ${i} on ${this._clients[i].clientDescription} on host ${this._host}`)
 			if (this._debug) console.log(`Connect client ${i} on ${this._clients[i].clientDescription} on host ${this._host}`)
 			this._clients[i].client.connect()
 		}
@@ -256,6 +257,7 @@ export class NCSServerConnection extends EventEmitter implements INCSServerConne
 					.catch((e) => {
 						// probably a timeout
 						client.heartbeatConnected = false
+						this.emit('error', `Heartbeat error on ${this._clients[key].clientDescription}: ${e.toString()}`)
 						if (this._debug) console.log(`Heartbeat on ${this._clients[key].clientDescription}: ${e.toString()}`)
 					})
 				} else {

--- a/src/connection/mosSocketClient.ts
+++ b/src/connection/mosSocketClient.ts
@@ -428,6 +428,7 @@ export class MosSocketClient extends EventEmitter {
   /** */
 	private _onError (error: Error) {
 		// dispatch error!!!!!
+		this.emit('error', `Socket event error: ${error.message}`)
 		if (this._debug) console.log(`Socket event error: ${error.message}`)
 	}
 
@@ -436,6 +437,7 @@ export class MosSocketClient extends EventEmitter {
 		this.connected = false
 		// this._readyToSendMessage = false
 		if (hadError) {
+			this.emit('warning', 'Scoket closed with error')
 			if (this._debug) console.log('Socket closed with error')
 		} else {
 			if (this._debug) console.log('Socket closed without error')
@@ -444,6 +446,7 @@ export class MosSocketClient extends EventEmitter {
 		this.emit(SocketConnectionEvent.DISCONNECTED)
 
 		if (this._shouldBeConnected === true) {
+			this.emit('warning', 'Socket shouod reconnect')
 			if (this._debug) console.log('Socket should reconnect')
 			this.connect()
 		}

--- a/src/connection/mosSocketClient.ts
+++ b/src/connection/mosSocketClient.ts
@@ -446,7 +446,7 @@ export class MosSocketClient extends EventEmitter {
 		this.emit(SocketConnectionEvent.DISCONNECTED)
 
 		if (this._shouldBeConnected === true) {
-			this.emit('warning', 'Socket shouod reconnect')
+			this.emit('warning', 'Socket should reconnect')
 			if (this._debug) console.log('Socket should reconnect')
 			this.connect()
 		}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

* **What is the current behavior?** (You can also link to an open issue here)

Too much logging information. Duplication of logging emitted and sent to the console.

* **What is the new behavior (if this is a feature change)?**

Debug flag should be set to false to switch of console logging. Changes ensure all valuable information is emitted.

* **Other information**:

Related to https://github.com/nrkno/tv-automation-mos-gateway/pull/26
