### PR TITLE
feat: support url encoded stringified JSON data in MosExternalMetaData payload

### DIFF
--- a/src/dataTypes/__tests__/mosExternalMetaData.spec.ts
+++ b/src/dataTypes/__tests__/mosExternalMetaData.spec.ts
@@ -22,8 +22,8 @@ describe('mosExternalMetaData', () => {
 	})
 
 	test('Detect and parse Nora content JSON payload', () => {
-		const contentPayload = {"uuid":"b665e0f0-9b44-496a-8753-676d81f33ab7","metadata":{"modul":"no"}}
-	
+		const contentPayload = { 'uuid': 'b665e0f0-9b44-496a-8753-676d81f33ab7','metadata': { 'modul': 'no' } }
+
 		const actual = new MosExternalMetaData({
 			MosScope: IMOSScope.PLAYLIST,
 			MosSchema: 'https://nora.nrk.no/mos/content',
@@ -34,8 +34,8 @@ describe('mosExternalMetaData', () => {
 	})
 
 	test('Detect and parse Nora timing JSON payload', () => {
-		const timingPayload = {"timeIn":0,"duration":5000,"in":"auto","out":"auto"}
-	
+		const timingPayload = { 'timeIn': 0,'duration': 5000,'in': 'auto','out': 'auto' }
+
 		const actual = new MosExternalMetaData({
 			MosScope: IMOSScope.PLAYLIST,
 			MosSchema: 'https://nora.nrk.no/mos/timing',

--- a/src/dataTypes/__tests__/mosExternalMetaData.spec.ts
+++ b/src/dataTypes/__tests__/mosExternalMetaData.spec.ts
@@ -20,4 +20,52 @@ describe('mosExternalMetaData', () => {
 
 		expect(md.messageXMLBlocks.end()).toEqual('<?xml version=\"1.0\"?><mosExternalMetadata><mosScope>STORY</mosScope><mosSchema>http://ncsA4.com/mos/supported_schemas/NCSAXML2.08</mosSchema><mosPayload>hello world</mosPayload></mosExternalMetadata>')
 	})
+
+	test('Detect and parse Nora content JSON payload', () => {
+		const contentPayload = {"uuid":"b665e0f0-9b44-496a-8753-676d81f33ab7","metadata":{"modul":"no"}}
+	
+		const actual = new MosExternalMetaData({
+			MosScope: IMOSScope.PLAYLIST,
+			MosSchema: 'https://nora.nrk.no/mos/content',
+			MosPayload: encodeURI(JSON.stringify(contentPayload))
+		})
+
+		expect(actual.payload).toEqual(contentPayload)
+	})
+
+	test('Detect and parse Nora timing JSON payload', () => {
+		const timingPayload = {"timeIn":0,"duration":5000,"in":"auto","out":"auto"}
+	
+		const actual = new MosExternalMetaData({
+			MosScope: IMOSScope.PLAYLIST,
+			MosSchema: 'https://nora.nrk.no/mos/timing',
+			MosPayload: encodeURI(JSON.stringify(timingPayload))
+		})
+
+		expect(actual.payload).toEqual(timingPayload)
+	})
+
+	test('Should not decode URI encoded data that is not a JSON object', () => {
+		const content = encodeURI('This is not a JSON object')
+
+		const actual = new MosExternalMetaData({
+			MosScope: IMOSScope.PLAYLIST,
+			MosSchema: 'https://nora.nrk.no/mos/content',
+			MosPayload: content
+		})
+
+		expect(actual.payload).toEqual(content)
+	})
+
+	test('Should not decode URI encoded data that is not a valid JSON object', () => {
+		const content = encodeURI('{"lol:"This is not a JSON object"')
+
+		const actual = new MosExternalMetaData({
+			MosScope: IMOSScope.PLAYLIST,
+			MosSchema: 'https://nora.nrk.no/mos/content',
+			MosPayload: content
+		})
+
+		expect(actual.payload).toEqual(content)
+	})
 })

--- a/src/dataTypes/mosExternalMetaData.ts
+++ b/src/dataTypes/mosExternalMetaData.ts
@@ -22,15 +22,14 @@ export class MosExternalMetaData {
 	constructor (obj: IMOSExternalMetaData) {
 		this._scope = obj.MosScope
 		this._schema = obj.MosSchema
-		try{
+		try {
 			const decoded = decodeURI(obj.MosPayload).trim()
-			if(decoded.startsWith('{')) {
+			if (decoded.startsWith('{')) {
 				this._payload = JSON.parse(decoded)
 			} else {
 				this._payload = obj.MosPayload
 			}
-		}
-		catch (err) {
+		} catch (err) {
 			this._payload = obj.MosPayload
 		}
 		// this._payload = obj.MosPayload

--- a/src/dataTypes/mosExternalMetaData.ts
+++ b/src/dataTypes/mosExternalMetaData.ts
@@ -22,7 +22,18 @@ export class MosExternalMetaData {
 	constructor (obj: IMOSExternalMetaData) {
 		this._scope = obj.MosScope
 		this._schema = obj.MosSchema
-		this._payload = obj.MosPayload
+		try{
+			const decoded = decodeURI(obj.MosPayload).trim()
+			if(decoded.startsWith('{')) {
+				this._payload = JSON.parse(decoded)
+			} else {
+				this._payload = obj.MosPayload
+			}
+		}
+		catch (err) {
+			this._payload = obj.MosPayload
+		}
+		// this._payload = obj.MosPayload
 	}
 
 	get scope (): IMOSScope | undefined {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a new feature, expanding the current parser functionality

* **What is the current behavior?** (You can also link to an open issue here)
Data will be parsed as XML content if it is XML or passed on verbatim as a string


* **What is the new behavior (if this is a feature change)?**
If the payload content URI decoded is a valid JSON object it will be stored (and returned) as an object

